### PR TITLE
Update the README to reflect the required Rake-task options

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ Configure the task in your `Rakefile`:
 require 'github_changelog_generator/task'
 
 GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  config.user = 'username'
+  config.project = 'project-name'
   config.since_tag = '0.1.14'
   config.future_release = '0.2.0'
 end


### PR DESCRIPTION
PR #451 removes the repo-guessing code, which both:

* allows the user and project to be set in the Rake task
* **requires** the user and project to be set in the Rake task

This PR updates the Rake example in the README to reflect this new usage.