### PR TITLE
Remove threading and use caching

### DIFF
--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -18,34 +18,24 @@ module GitHubChangelogGenerator
     # Async fetching of all tags dates
     def fetch_tags_dates(tags)
       print "Fetching tag dates...\r" if options[:verbose]
-      # Async fetching tags:
-      threads = []
       i = 0
-      all = tags.count
       tags.each do |tag|
-        print "                                 \r"
-        threads << Thread.new do
-          get_time_of_tag(tag)
-          print "Fetching tags dates: #{i + 1}/#{all}\r" if options[:verbose]
-          i += 1
-        end
+        get_time_of_tag(tag)
+        i += 1
       end
-      threads.each(&:join)
-      puts "Fetching tags dates: #{i}" if options[:verbose]
+      puts "Fetching tags dates: #{i}/#{tags.count}" if options[:verbose]
     end
 
     # Find correct closed dates, if issues was closed by commits
     def detect_actual_closed_dates(issues)
       print "Fetching closed dates for issues...\r" if options[:verbose]
 
-      issues.each_slice(MAX_THREAD_NUMBER) do |issues_slice|
-        threads = []
-        issues_slice.each do |issue|
-          threads << Thread.new { find_closed_date_by_commit(issue) }
-        end
-        threads.each(&:join)
+      i = 0
+      issues.each do |issue|
+        find_closed_date_by_commit(issue)
+        i += 1
       end
-      puts "Fetching closed dates for issues: Done!" if options[:verbose]
+      puts "Fetching closed dates for issues: #{i}/#{issues.count}" if options[:verbose]
     end
 
     # Adds a key "first_occurring_tag" to each PR with a value of the oldest
@@ -190,7 +180,7 @@ module GitHubChangelogGenerator
         issue["actual_date"] = issue["closed_at"]
       else
         begin
-          commit = @fetcher.fetch_commit(event)
+          commit = @fetcher.fetch_commit(event["commit_id"])
           issue["actual_date"] = commit["commit"]["author"]["date"]
 
           # issue['actual_date'] = commit['author']['date']

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -238,7 +238,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
     #
     # @return [Time] time of specified tag
     def fetch_date_of_tag(tag)
-      commit_data = check_github_response { @client.commit(user_project, tag["commit"]["sha"]) }
+      commit_data = fetch_commit(tag["commit"]["sha"])
       commit_data = stringify_keys_deep(commit_data.to_hash)
 
       commit_data["commit"]["committer"]["date"]
@@ -260,17 +260,18 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
 
     # Fetch commit for specified event
     #
+    # @param [String] commit_id the SHA of a commit to fetch
     # @return [Hash]
-    def fetch_commit(event)
+    def fetch_commit(commit_id)
       found = commits.find do |commit|
-        commit["sha"] == event["commit_id"]
+        commit["sha"] == commit_id
       end
       if found
         stringify_keys_deep(found.to_hash)
       else
         # cache miss; don't add to @commits because unsure of order.
         check_github_response do
-          commit = @client.commit(user_project, event["commit_id"])
+          commit = @client.commit(user_project, commit_id)
           commit = stringify_keys_deep(commit.to_hash)
           commit
         end


### PR DESCRIPTION
The octo_fetcher caches the commits, so removing the threading around methods requesting commits from the cache reduces CPU time and memory usage.

Closes #651