### PR TITLE
Add release summary section

### DIFF
--- a/lib/github_changelog_generator/generator/entry.rb
+++ b/lib/github_changelog_generator/generator/entry.rb
@@ -123,6 +123,7 @@ module GitHubChangelogGenerator
     # @return [Array] Section objects.
     def default_sections
       [
+        Section.new(name: "summary", prefix: "", labels: @options[:summary_labels], options: @options, body_only:true),
         Section.new(name: "breaking", prefix: @options[:breaking_prefix], labels: @options[:breaking_labels], options: @options),
         Section.new(name: "enhancements", prefix: @options[:enhancement_prefix], labels: @options[:enhancement_labels], options: @options),
         Section.new(name: "bugs", prefix: @options[:bug_prefix], labels: @options[:bug_labels], options: @options),

--- a/lib/github_changelog_generator/generator/entry.rb
+++ b/lib/github_changelog_generator/generator/entry.rb
@@ -123,7 +123,7 @@ module GitHubChangelogGenerator
     # @return [Array] Section objects.
     def default_sections
       [
-        Section.new(name: "summary", prefix: "", labels: @options[:summary_labels], options: @options, body_only:true),
+        Section.new(name: "summary", prefix: @options[:summary_prefix], labels: @options[:summary_labels], options: @options, body_only:true),
         Section.new(name: "breaking", prefix: @options[:breaking_prefix], labels: @options[:breaking_labels], options: @options),
         Section.new(name: "enhancements", prefix: @options[:enhancement_prefix], labels: @options[:enhancement_labels], options: @options),
         Section.new(name: "bugs", prefix: @options[:bug_prefix], labels: @options[:bug_labels], options: @options),

--- a/lib/github_changelog_generator/generator/section.rb
+++ b/lib/github_changelog_generator/generator/section.rb
@@ -5,7 +5,7 @@ module GitHubChangelogGenerator
   #
   # @see GitHubChangelogGenerator::Entry
   class Section
-    attr_accessor :name, :prefix, :issues, :labels
+    attr_accessor :name, :prefix, :issues, :labels, :body_only
 
     def initialize(opts = {})
       @name = opts[:name]
@@ -13,6 +13,7 @@ module GitHubChangelogGenerator
       @labels = opts[:labels] || []
       @issues = opts[:issues] || []
       @options = opts[:options] || Options.new({})
+      @body_only = opts[:body_only] || false
     end
 
     # Returns the content of a section.
@@ -22,10 +23,11 @@ module GitHubChangelogGenerator
       content = ""
 
       if @issues.any?
-        content += "#{@prefix}\n\n" unless @options[:simple_list]
+        content += "#{@prefix}\n\n" unless @options[:simple_list] || @prefix.blank?
         @issues.each do |issue|
           merge_string = get_string_for_issue(issue)
-          content += "- #{merge_string}\n"
+          content += "- " unless @body_only
+          content += "#{merge_string}\n"
         end
         content += "\n"
       end
@@ -54,6 +56,7 @@ module GitHubChangelogGenerator
 
     def issue_line_with_body(line, issue)
       return line if !@options[:issue_line_body] || issue["body"].blank?
+      return encapsulate_string(issue["body"]) if @body_only
       # get issue body till first line break
       body_paragraph = body_till_first_break(issue["body"])
       # remove spaces from begining and end of the string

--- a/lib/github_changelog_generator/generator/section.rb
+++ b/lib/github_changelog_generator/generator/section.rb
@@ -55,8 +55,8 @@ module GitHubChangelogGenerator
     end
 
     def issue_line_with_body(line, issue)
+      return issue["body"] if @body_only && issue["body"].present?
       return line if !@options[:issue_line_body] || issue["body"].blank?
-      return encapsulate_string(issue["body"]) if @body_only
       # get issue body till first line break
       body_paragraph = body_till_first_break(issue["body"])
       # remove spaces from begining and end of the string

--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -64,6 +64,7 @@ module GitHubChangelogGenerator
       since_tag
       ssl_ca_file
       summary_labels
+      summary_prefix
       token
       unreleased
       unreleased_label

--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -63,6 +63,7 @@ module GitHubChangelogGenerator
       simple_list
       since_tag
       ssl_ca_file
+      summary_labels
       token
       unreleased
       unreleased_label

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -236,7 +236,7 @@ module GitHubChangelogGenerator
         unreleased_label: "Unreleased",
         compare_link: true,
         exclude_labels: ["duplicate", "question", "invalid", "wontfix", "Duplicate", "Question", "Invalid", "Wontfix", "Meta: Exclude From Changelog"],
-        summary_labels: ["Release-summary", "release-summary", "Summary", "summary"],
+        summary_labels: ["Release summary", "release-summary", "Summary", "summary"],
         breaking_labels: ["backwards-incompatible", "Backwards incompatible", "breaking"],
         enhancement_labels: ["enhancement", "Enhancement", "Type: Enhancement"],
         bug_labels: ["bug", "Bug", "Type: Bug"],

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -131,6 +131,9 @@ module GitHubChangelogGenerator
         opts.on("--exclude-labels  x,y,z", Array, "Issues with the specified labels will be excluded from changelog. Default is 'duplicate,question,invalid,wontfix'.") do |list|
           options[:exclude_labels] = list
         end
+        opts.on("--summary-labels x,y,z", Array, 'Issues with these labels will be added to a new section, called "Release Summary". The section display only body of issues. Default is \'release-summary,summary\'.') do |list|
+          options[:summary_labels] = list
+        end
         opts.on("--breaking-labels x,y,z", Array, 'Issues with these labels will be added to a new section, called "Breaking changes". Default is \'backwards-incompatible,breaking\'.') do |list|
           options[:breaking_labels] = list
         end
@@ -230,6 +233,7 @@ module GitHubChangelogGenerator
         unreleased_label: "Unreleased",
         compare_link: true,
         exclude_labels: ["duplicate", "question", "invalid", "wontfix", "Duplicate", "Question", "Invalid", "Wontfix", "Meta: Exclude From Changelog"],
+        summary_labels: ["Release-summary", "release-summary", "Summary", "summary"],
         breaking_labels: ["backwards-incompatible", "Backwards incompatible", "breaking"],
         enhancement_labels: ["enhancement", "Enhancement", "Type: Enhancement"],
         bug_labels: ["bug", "Bug", "Type: Bug"],

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -56,6 +56,9 @@ module GitHubChangelogGenerator
         opts.on("-b", "--base [NAME]", "Optional base file to append generated changes to.") do |last|
           options[:base] = last
         end
+        opts.on("--summary-label [LABEL]", "Set up custom label for the release summary section. Default is \"\".") do |v|
+          options[:summary_prefix] = v
+        end
         opts.on("--breaking-label [LABEL]", "Set up custom label for the breaking changes section. Default is \"**Breaking changes:**\".") do |v|
           options[:breaking_prefix] = v
         end
@@ -250,6 +253,7 @@ module GitHubChangelogGenerator
         header: "# Changelog",
         merge_prefix: "**Merged pull requests:**",
         issue_prefix: "**Closed issues:**",
+        summary_prefix: "",
         breaking_prefix: "**Breaking changes:**",
         enhancement_prefix: "**Implemented enhancements:**",
         bug_prefix: "**Fixed bugs:**",

--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -67,7 +67,7 @@ module GitHubChangelogGenerator
     end
 
     KNOWN_ARRAY_KEYS = %i[exclude_labels include_labels
-                          breaking_labels enhancement_labels bug_labels
+                          summary_labels breaking_labels enhancement_labels bug_labels
                           deprecated_labels removed_labels security_labels
                           issue_line_labels between_tags exclude_tags]
     KNOWN_INTEGER_KEYS = [:max_issues]

--- a/man/git-generate-changelog.1
+++ b/man/git-generate-changelog.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-GENERATE\-CHANGELOG" "1" "April 2018" "" ""
+.TH "GIT\-GENERATE\-CHANGELOG" "1" "May 2018" "" ""
 .
 .SH "NAME"
 \fBgit\-generate\-changelog\fR \- Generate changelog from GitHub
@@ -47,6 +47,12 @@ Output file\. To print to STDOUT instead, use blank as path\. Default is CHANGEL
 .
 .P
 Optional base file to append generated changes to\.
+.
+.P
+\-\-summary\-label [LABEL]
+.
+.P
+Set up custom label for the release summary section\. Default is ""\.
 .
 .P
 \-\-breaking\-label [LABEL]
@@ -197,6 +203,12 @@ Of the labeled issues, only include the ones with the specified labels\.
 .
 .P
 Issues with the specified labels will be excluded from changelog\. Default is \'duplicate,question,invalid,wontfix\'\.
+.
+.P
+\-\-summary\-labels x,y,z
+.
+.P
+Issues with these labels will be added to a new section, called "Release Summary"\. The section display only body of issues\. Default is \'Release summary,release\-summary,Summary,summary\'\.
 .
 .P
 \-\-breaking\-labels x,y,z

--- a/man/git-generate-changelog.1.html
+++ b/man/git-generate-changelog.1.html
@@ -109,6 +109,10 @@
 
 <p>  Optional base file to append generated changes to.</p>
 
+<p>  --summary-label [LABEL]</p>
+
+<p>  Set up custom label for the release summary section. Default is "".</p>
+
 <p>  --breaking-label [LABEL]</p>
 
 <p>  Set up custom label for breaking changes section. Default is "<strong>Breaking changes:</strong>".</p>
@@ -208,6 +212,10 @@
 <p>  --exclude-labels x,y,z</p>
 
 <p>  Issues with the specified labels will be excluded from changelog. Default is 'duplicate,question,invalid,wontfix'.</p>
+
+<p>  --summary-labels x,y,z</p>
+
+<p>  Issues with these labels will be added to a new section, called "Release Summary". The section display only body of issues. Default is 'Release summary,release-summary,Summary,summary'.</p>
 
 <p>  --breaking-labels x,y,z</p>
 
@@ -334,7 +342,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>April 2018</li>
+    <li class='tc'>May 2018</li>
     <li class='tr'>git-generate-changelog(1)</li>
   </ol>
 

--- a/man/git-generate-changelog.md
+++ b/man/git-generate-changelog.md
@@ -35,6 +35,10 @@ Automatically generate changelog from your tags, issues, labels and pull request
 
   Optional base file to append generated changes to.
 
+  --summary-label [LABEL]
+
+  Set up custom label for the release summary section. Default is "".
+
   --breaking-label [LABEL]
 
   Set up custom label for breaking changes section. Default is "**Breaking changes:**".
@@ -134,6 +138,10 @@ Automatically generate changelog from your tags, issues, labels and pull request
   --exclude-labels x,y,z
 
   Issues with the specified labels will be excluded from changelog. Default is 'duplicate,question,invalid,wontfix'.
+
+  --summary-labels x,y,z
+
+  Issues with these labels will be added to a new section, called "Release Summary". The section display only body of issues. Default is 'Release summary,release-summary,Summary,summary'.
 
   --breaking-labels x,y,z
 


### PR DESCRIPTION
This PR allows us to create section for release summary.

Add the body of the issues with `release-sumary` label.
You can add attractive images and summary text about each releases.

---

- **--summary-labels x,y,z**

Issues with these labels will be added to a new section, called "Release Summary".

The section display only body of issues.

Default: **'Release-summary,release-summary,Summary,summary'**


---

This PR will fix #582