### PR TITLE
Added rudimentary gitlab support

### DIFF
--- a/lib/github_changelog_generator/generator/generator.rb
+++ b/lib/github_changelog_generator/generator/generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "github_changelog_generator/octo_fetcher"
+require "github_changelog_generator/gitlab_fetcher"
 require "github_changelog_generator/generator/generator_fetcher"
 require "github_changelog_generator/generator/generator_processor"
 require "github_changelog_generator/generator/generator_tags"
@@ -34,7 +35,7 @@ module GitHubChangelogGenerator
     def initialize(options = {})
       @options        = options
       @tag_times_hash = {}
-      @fetcher        = GitHubChangelogGenerator::OctoFetcher.new(options)
+      @fetcher        = options[:gitlab] ? GitHubChangelogGenerator::GitlabFetcher.new(options) : GitHubChangelogGenerator::OctoFetcher.new(options)
       @sections       = []
     end
 

--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -165,7 +165,7 @@ module GitHubChangelogGenerator
     # @param [Hash] issue
     def find_closed_date_by_commit(issue)
       unless issue["events"].nil?
-        # if it's PR -> then find "merged event", in case of usual issue -> fond closed date
+        # if it's PR -> then find "merged event", in case of usual issue -> find closed date
         compare_string = issue["merged_at"].nil? ? "closed" : "merged"
         # reverse! - to find latest closed event. (event goes in date order)
         issue["events"].reverse!.each do |event|

--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -75,9 +75,16 @@ module GitHubChangelogGenerator
         # fetch that. See
         # https://developer.github.com/v3/pulls/#get-a-single-pull-request vs.
         # https://developer.github.com/v3/pulls/#list-pull-requests
-        if pr["events"] && (event = pr["events"].find { |e| e["event"] == "merged" })
+        # gitlab API has this
+        merge_commit_sha = nil
+        if pr.has_key?("merge_commit_sha") then
+          merge_commit_sha = pr["merge_commit_sha"]
+        elsif pr["events"] && (event = pr["events"].find { |e| e["event"] == "merged" })
+          merge_commit_sha = event["commit_id"]
+        end
+        unless merge_commit_sha.nil?
           # Iterate tags.reverse (oldest to newest) to find first tag of each PR.
-          if (oldest_tag = tags.reverse.find { |tag| tag["shas_in_tag"].include?(event["commit_id"]) })
+          if (oldest_tag = tags.reverse.find { |tag| tag["shas_in_tag"].include?(merge_commit_sha) })
             pr["first_occurring_tag"] = oldest_tag["name"]
             found = true
             i += 1

--- a/lib/github_changelog_generator/gitlab_fetcher.rb
+++ b/lib/github_changelog_generator/gitlab_fetcher.rb
@@ -1,0 +1,479 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "retriable"
+require
+module GitHubChangelogGenerator
+  # A Fetcher responsible for all requests to GitHub and all basic manipulation with related data
+  # (such as filtering, validating, e.t.c)
+  #
+  # Example:
+  # fetcher = GitHubChangelogGenerator::OctoFetcher.new(options)
+  class GitlabFetcher
+    PER_PAGE_NUMBER   = 100
+    MAX_THREAD_NUMBER = 25
+    MAX_FORBIDDEN_RETRIES = 100
+    CHANGELOG_GITHUB_TOKEN = "CHANGELOG_GITHUB_TOKEN"
+    GH_RATE_LIMIT_EXCEEDED_MSG = "Warning: Can't finish operation: GitHub API rate limit exceeded, changelog may be " \
+    "missing some issues. You can limit the number of issues fetched using the `--max-issues NUM` argument."
+    NO_TOKEN_PROVIDED = "Warning: No token provided (-t option) and variable $CHANGELOG_GITHUB_TOKEN was not found. " \
+    "This script can make only 50 requests to GitHub API per hour without token!"
+
+    # @param options [Hash] Options passed in
+    # @option options [String] :user GitHub username
+    # @option options [String] :project GitHub project
+    # @option options [String] :since Only issues updated at or after this time are returned. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. eg. Time.parse("2016-01-01 10:00:00").iso8601
+    # @option options [Boolean] :http_cache Use ActiveSupport::Cache::FileStore to cache http requests
+    # @option options [Boolean] :cache_file If using http_cache, this is the cache file path
+    # @option options [Boolean] :cache_log If using http_cache, this is the cache log file path
+    def initialize(options = {})
+      @options      = options || {}
+      @user         = @options[:user]
+      @project      = @options[:project]
+      @since        = @options[:since]
+      @http_cache   = @options[:http_cache]
+      @cache_file   = nil
+      @cache_log    = nil
+      @commits      = []
+      @compares     = {}
+      # prepare_cache
+      # configure_octokit_ssl
+      @client = Gitlab::Client.new(github_options)
+    end
+
+    # def prepare_cache
+    #   return unless @http_cache
+    #   @cache_file = @options.fetch(:cache_file) { File.join(Dir.tmpdir, "github-changelog-http-cache") }
+    #   @cache_log  = @options.fetch(:cache_log) { File.join(Dir.tmpdir, "github-changelog-logger.log") }
+    #   init_cache
+    # end
+
+    def github_options
+      result = {}
+      github_token = fetch_github_token
+      result[:access_token] = github_token if github_token
+      endpoint = @options[:github_endpoint]
+      result[:api_endpoint] = endpoint if endpoint
+      result
+    end
+
+    # def configure_octokit_ssl
+    #   ca_file = @options[:ssl_ca_file] || ENV["SSL_CA_FILE"] || File.expand_path("ssl_certs/cacert.pem", __dir__)
+    #   Octokit.connection_options = { ssl: { ca_file: ca_file } }
+    # end
+
+    # def init_cache
+    #   Octokit.middleware = Faraday::RackBuilder.new do |builder|
+    #     builder.use(Faraday::HttpCache, serializer: Marshal,
+    #                                     store: ActiveSupport::Cache::FileStore.new(@cache_file),
+    #                                     logger: Logger.new(@cache_log),
+    #                                     shared_cache: false)
+    #     builder.use Octokit::Response::RaiseError
+    #     builder.adapter Faraday.default_adapter
+    #     # builder.response :logger
+    #   end
+    # end
+
+    DEFAULT_REQUEST_OPTIONS = { per_page: PER_PAGE_NUMBER }
+
+    # Fetch all tags from repo
+    #
+    # @return [Array <Hash>] array of tags
+    def get_all_tags
+      print "Fetching tags...\r" if @options[:verbose]
+
+      check_github_response { github_fetch_tags }
+    end
+
+    # # Returns the number of pages for a API call
+    # #
+    # # @return [Integer] number of pages for this API call in total
+    # def calculate_pages(client, method, request_options)
+    #   # Makes the first API call so that we can call last_response
+    #   check_github_response do
+    #     client.send(method, user_project, DEFAULT_REQUEST_OPTIONS.merge(request_options))
+    #   end
+    #
+    #   last_response = client.last_response
+    #
+    #   if (last_pg = last_response.rels[:last])
+    #     querystring_as_hash(last_pg.href)["page"].to_i
+    #   else
+    #     1
+    #   end
+    # end
+
+    # Fill input array with tags
+    #
+    # @return [Array <Hash>] array of tags in repo
+    def github_fetch_tags
+      tags        = []
+      page_i      = 0
+      count_pages = calculate_pages(@client, "tags", {})
+
+      iterate_pages(@client, "tags") do |new_tags|
+        page_i += PER_PAGE_NUMBER
+        print_in_same_line("Fetching tags... #{page_i}/#{count_pages * PER_PAGE_NUMBER}")
+        tags.concat(new_tags)
+      end
+      print_empty_line
+
+      if tags.count == 0
+        Helper.log.warn "Warning: Can't find any tags in repo. \
+Make sure, that you push tags to remote repo via 'git push --tags'"
+      else
+        Helper.log.info "Found #{tags.count} tags"
+      end
+      # tags are a Sawyer::Resource. Convert to hash
+      tags.map { |resource| stringify_keys_deep(resource.to_hash) }
+    end
+
+    def closed_pr_options
+      @closed_pr_options ||= {
+        filter: "all", labels: nil, state: "closed"
+      }.tap { |options| options[:since] = @since if @since }
+    end
+
+    # This method fetch all closed issues and separate them to pull requests and pure issues
+    # (pull request is kind of issue in term of GitHub)
+    #
+    # @return [Tuple] with (issues [Array <Hash>], pull-requests [Array <Hash>])
+    def fetch_closed_issues_and_pr
+      print "Fetching closed issues...\r" if @options[:verbose]
+      issues = []
+      page_i      = 0
+      count_pages = calculate_pages(@client, "issues", closed_pr_options)
+
+      iterate_pages(@client, "issues", closed_pr_options) do |new_issues|
+        page_i += PER_PAGE_NUMBER
+        print_in_same_line("Fetching issues... #{page_i}/#{count_pages * PER_PAGE_NUMBER}")
+        issues.concat(new_issues)
+        break if @options[:max_issues] && issues.length >= @options[:max_issues]
+      end
+      print_empty_line
+      Helper.log.info "Received issues: #{issues.count}"
+
+      # separate arrays of issues and pull requests:
+      issues.map { |issue| stringify_keys_deep(issue.to_hash) }
+            .partition { |issue_or_pr| issue_or_pr["pull_request"].nil? }
+    end
+
+    # Fetch all pull requests. We need them to detect :merged_at parameter
+    #
+    # @return [Array <Hash>] all pull requests
+    def fetch_closed_pull_requests
+      pull_requests = []
+      options = { state: "closed" }
+
+      page_i      = 0
+      count_pages = calculate_pages(@client, "pull_requests", options)
+
+      iterate_pages(@client, "pull_requests", options) do |new_pr|
+        page_i += PER_PAGE_NUMBER
+        log_string = "Fetching merged dates... #{page_i}/#{count_pages * PER_PAGE_NUMBER}"
+        print_in_same_line(log_string)
+        pull_requests.concat(new_pr)
+      end
+      print_empty_line
+
+      Helper.log.info "Pull Request count: #{pull_requests.count}"
+      pull_requests.map { |pull_request| stringify_keys_deep(pull_request.to_hash) }
+    end
+
+    # Fetch event for all issues and add them to 'events'
+    #
+    # @param [Array] issues
+    # @return [Void]
+    def fetch_events_async(issues)
+      i       = 0
+      threads = []
+
+      issues.each_slice(MAX_THREAD_NUMBER) do |issues_slice|
+        issues_slice.each do |issue|
+          threads << Thread.new do
+            issue["events"] = []
+            iterate_pages(@client, "issue_events", issue["number"]) do |new_event|
+              issue["events"].concat(new_event)
+            end
+            issue["events"] = issue["events"].map { |event| stringify_keys_deep(event.to_hash) }
+            print_in_same_line("Fetching events for issues and PR: #{i + 1}/#{issues.count}")
+            i += 1
+          end
+        end
+        threads.each(&:join)
+        threads = []
+      end
+
+      # to clear line from prev print
+      print_empty_line
+
+      Helper.log.info "Fetching events for issues and PR: #{i}"
+    end
+
+    # Fetch comments for PRs and add them to "comments"
+    #
+    # @param [Array] prs The array of PRs.
+    # @return [Void] No return; PRs are updated in-place.
+    def fetch_comments_async(prs)
+      threads = []
+
+      prs.each_slice(MAX_THREAD_NUMBER) do |prs_slice|
+        prs_slice.each do |pr|
+          threads << Thread.new do
+            pr["comments"] = []
+            iterate_pages(@client, "issue_comments", pr["number"]) do |new_comment|
+              pr["comments"].concat(new_comment)
+            end
+            pr["comments"] = pr["comments"].map { |comment| stringify_keys_deep(comment.to_hash) }
+          end
+        end
+        threads.each(&:join)
+        threads = []
+      end
+      nil
+    end
+
+    # Fetch tag time from repo
+    #
+    # @param [Hash] tag GitHub data item about a Tag
+    #
+    # @return [Time] time of specified tag
+    def fetch_date_of_tag(tag)
+      commit_data = fetch_commit(tag["commit"]["sha"])
+      commit_data = stringify_keys_deep(commit_data.to_hash)
+
+      commit_data["commit"]["committer"]["date"]
+    end
+
+    # Fetch and cache comparison between two github refs
+    #
+    # @param [String] older The older sha/tag/branch.
+    # @param [String] newer The newer sha/tag/branch.
+    # @return [Hash] Github api response for comparison.
+    def fetch_compare(older, newer)
+      unless @compares["#{older}...#{newer}"]
+        compare_data = check_github_response { @client.compare(user_project, older, newer || "HEAD") }
+        raise StandardError, "Sha #{older} and sha #{newer} are not related; please file a github-changelog-generator issues and describe how to replicate this issue." if compare_data["status"] == "diverged"
+        @compares["#{older}...#{newer}"] = stringify_keys_deep(compare_data.to_hash)
+      end
+      @compares["#{older}...#{newer}"]
+    end
+
+    # Fetch commit for specified event
+    #
+    # @param [String] commit_id the SHA of a commit to fetch
+    # @return [Hash]
+    def fetch_commit(commit_id)
+      found = commits.find do |commit|
+        commit["sha"] == commit_id
+      end
+      if found
+        stringify_keys_deep(found.to_hash)
+      else
+        # cache miss; don't add to @commits because unsure of order.
+        check_github_response do
+          commit = @client.commit(user_project, commit_id)
+          commit = stringify_keys_deep(commit.to_hash)
+          commit
+        end
+      end
+    end
+
+    # Fetch all commits
+    #
+    # @return [Array] Commits in a repo.
+    def commits
+      if @commits.empty?
+        iterate_pages(@client, "commits") do |new_commits|
+          @commits.concat(new_commits)
+        end
+      end
+      @commits
+    end
+
+    # Return the oldest commit in a repo
+    #
+    # @return [Hash] Oldest commit in the github git history.
+    def oldest_commit
+      commits.last
+    end
+
+    # @return [String] Default branch of the repo
+    def default_branch
+      @default_branch ||= @client.repository(user_project)[:default_branch]
+    end
+
+    # Fetch all SHAs occurring in or before a given tag and add them to
+    # "shas_in_tag"
+    #
+    # @param [Array] tags The array of tags.
+    # @return [Nil] No return; tags are updated in-place.
+    def fetch_tag_shas_async(tags)
+      i = 0
+      threads = []
+      print_in_same_line("Fetching SHAs for tags: #{i}/#{tags.count}\r") if @options[:verbose]
+
+      tags.each_slice(MAX_THREAD_NUMBER) do |tags_slice|
+        tags_slice.each do |tag|
+          threads << Thread.new do
+            # Use oldest commit because comparing two arbitrary tags may be diverged
+            commits_in_tag = fetch_compare(oldest_commit["sha"], tag["name"])
+            tag["shas_in_tag"] = commits_in_tag["commits"].collect { |commit| commit["sha"] }
+            print_in_same_line("Fetching SHAs for tags: #{i + 1}/#{tags.count}") if @options[:verbose]
+            i += 1
+          end
+        end
+        threads.each(&:join)
+        threads = []
+      end
+
+      # to clear line from prev print
+      print_empty_line
+
+      Helper.log.info "Fetching SHAs for tags: #{i}"
+      nil
+    end
+
+    private
+
+    def stringify_keys_deep(indata)
+      case indata
+      when Array
+        indata.map do |value|
+          stringify_keys_deep(value)
+        end
+      when Hash
+        indata.each_with_object({}) do |(key, value), output|
+          output[key.to_s] = stringify_keys_deep(value)
+        end
+      else
+        indata
+      end
+    end
+
+    # Exception raised to warn about moved repositories.
+    MovedPermanentlyError = Class.new(RuntimeError)
+
+    # Iterates through all pages until there are no more :next pages to follow
+    # yields the result per page
+    #
+    # @param [Octokit::Client] client
+    # @param [String] method (eg. 'tags')
+    #
+    # @yield [Sawyer::Resource] An OctoKit-provided response (which can be empty)
+    #
+    # @return [void]
+    def iterate_pages(client, method, *args)
+      args << DEFAULT_REQUEST_OPTIONS.merge(extract_request_args(args))
+
+      check_github_response { client.send(method, user_project, *args) }
+      last_response = client.last_response.tap do |response|
+        raise(MovedPermanentlyError, response.data[:url]) if response.status == 301
+      end
+
+      yield(last_response.data)
+
+      until (next_one = last_response.rels[:next]).nil?
+        last_response = check_github_response { next_one.get }
+        yield(last_response.data)
+      end
+    end
+
+    def extract_request_args(args)
+      if args.size == 1 && args.first.is_a?(Hash)
+        args.delete_at(0)
+      elsif args.size > 1 && args.last.is_a?(Hash)
+        args.delete_at(args.length - 1)
+      else
+        {}
+      end
+    end
+
+    # This is wrapper with rescue block
+    #
+    # @return [Object] returns exactly the same, what you put in the block, but wrap it with begin-rescue block
+    def check_github_response
+      Retriable.retriable(retry_options) do
+        yield
+      end
+    rescue MovedPermanentlyError => e
+      fail_with_message(e, "The repository has moved, update your configuration")
+    rescue Gitlab::Error::Forbidden => e
+      fail_with_message(e, "Exceeded retry limit")
+    rescue Gitlab::Error::Unauthorized => e
+      fail_with_message(e, "Error: wrong GitHub token")
+    end
+
+    # Presents the exception, and the aborts with the message.
+    def fail_with_message(error, message)
+      Helper.log.error("#{error.class}: #{error.message}")
+      sys_abort(message)
+    end
+
+    # Exponential backoff
+    def retry_options
+      {
+        on: [Gitlab::Error::Forbidden],
+        tries: MAX_FORBIDDEN_RETRIES,
+        base_interval: sleep_base_interval,
+        multiplier: 1.0,
+        rand_factor: 0.0,
+        on_retry: retry_callback
+      }
+    end
+
+    def sleep_base_interval
+      1.0
+    end
+
+    def retry_callback
+      proc do |exception, try, elapsed_time, next_interval|
+        Helper.log.warn("RETRY - #{exception.class}: '#{exception.message}'")
+        Helper.log.warn("#{try} tries in #{elapsed_time} seconds and #{next_interval} seconds until the next try")
+        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG
+        Helper.log.warn @client.rate_limit
+      end
+    end
+
+    def sys_abort(msg)
+      abort(msg)
+    end
+
+    # Print specified line on the same string
+    #
+    # @param [String] log_string
+    def print_in_same_line(log_string)
+      print log_string + "\r"
+    end
+
+    # Print long line with spaces on same line to clear prev message
+    def print_empty_line
+      print_in_same_line("                                                                       ")
+    end
+
+    # Returns GitHub token. First try to use variable, provided by --token option,
+    # otherwise try to fetch it from CHANGELOG_GITHUB_TOKEN env variable.
+    #
+    # @return [String]
+    def fetch_github_token
+      env_var = @options[:token].presence || ENV["CHANGELOG_GITHUB_TOKEN"]
+
+      Helper.log.warn NO_TOKEN_PROVIDED unless env_var
+
+      env_var
+    end
+
+    # @return [String] helper to return Github "user/project"
+    def user_project
+      "#{@options[:user]}/#{@options[:project]}"
+    end
+
+    # Returns Hash of all querystring variables in given URI.
+    #
+    # @param [String] uri eg. https://api.github.com/repositories/43914960/tags?page=37&foo=1
+    # @return [Hash] of all GET variables. eg. { 'page' => 37, 'foo' => 1 }
+    def querystring_as_hash(uri)
+      Hash[URI.decode_www_form(URI(uri).query || "")]
+    end
+  end
+end

--- a/lib/github_changelog_generator/gitlab_fetcher.rb
+++ b/lib/github_changelog_generator/gitlab_fetcher.rb
@@ -99,9 +99,8 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
     # @return [Tuple] with (issues [Array <Hash>], pull-requests [Array <Hash>])
     def fetch_closed_issues_and_pr
       print "Fetching closed issues...\r" if @options[:verbose]
-      print_empty_line
-      issues = @client.issues(@project_id, DEFAULT_REQUEST_OPTIONS)
-      p issues.first
+      options = { state: "closed",  scope: :all}
+      issues = @client.issues(@project_id, DEFAULT_REQUEST_OPTIONS.merge(options))
 
       print_empty_line
       Helper.log.info "Received issues: #{issues.count}"

--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -41,6 +41,7 @@ module GitHubChangelogGenerator
       future_release
       github_endpoint
       github_site
+      gitlab
       header
       http_cache
       include_labels

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -176,6 +176,9 @@ module GitHubChangelogGenerator
         opts.on("--github-api [URL]", "The enterprise endpoint to use for your GitHub API.") do |last|
           options[:github_endpoint] = last
         end
+        opts.on("--[no-]gitlab", "Use Gitlab API instead of Github. Default is false.") do |last|
+          options[:gitlab] = last
+        end
         opts.on("--simple-list", "Create a simple list from issues and pull requests. Default is false.") do |v|
           options[:simple_list] = v
         end
@@ -253,7 +256,8 @@ module GitHubChangelogGenerator
         removed_prefix: "**Removed:**",
         security_prefix: "**Security fixes:**",
         http_cache: true,
-        require: []
+        require: [],
+        gitlab: false
       )
     end
   end


### PR DESCRIPTION
This is my first attempt at adding Gitlab support to this very convenient project.
I took a copy of `octo_fetcher` and modified it to match the gitlab module.
It is pretty much rough around the edges and I am looking for feedback to nail down the last bits.
Tested on both  public gitlab.com [repo](https://gitlab.com/kreczko/changelog-testrepo) and a private instance (older gitlab version), the former is a bit slow.

While I can get a nice looking CHANGELOG from a test repo, the entries are not right (see below).

Outstanding issues:
 - the notation of PRs is different gitlab &harr; github (`!` vs `#`)
 - test issue number 2 in the example is not matched to the tag but the corresponding PR is.  `closed_at` of issue and creation time for tag are pointing to the same minute.



# Example changelog for public project
## [Unreleased](https://gitlab.com/kreczko/changelog-testrepo/tree/HEAD)

[Full Changelog](https://gitlab.com/kreczko/changelog-testrepo/compare/v0.0.0...HEAD)

**Closed issues:**

- Test issue number 2 [\#2](https://gitlab.com/kreczko/changelog-testrepo/issues/2)

## [v0.0.0](https://gitlab.com/kreczko/changelog-testrepo/tree/v0.0.0) (2018-05-30)

[Full Changelog](https://gitlab.com/kreczko/changelog-testrepo/compare/da97c416fbd1a36f7a93a816506dcfe47720f435...v0.0.0)

**Closed issues:**

- Test issue number 1 [\#1](https://gitlab.com/kreczko/changelog-testrepo/issues/1)

**Merged pull requests:**

- fixed \#2 [\#2](https://gitlab.com/kreczko/changelog-testrepo/merge_requests/2) ([kreczko](https://gitlab.com/kreczko))
- added testfile [\#1](https://gitlab.com/kreczko/changelog-testrepo/merge_requests/1) ([kreczko](https://gitlab.com/kreczko))



\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*