### PR TITLE
Update octo_fetcher.rb

### DIFF
--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -10,7 +10,7 @@ module GitHubChangelogGenerator
   # fetcher = GitHubChangelogGenerator::OctoFetcher.new(options)
   class OctoFetcher
     PER_PAGE_NUMBER   = 100
-    MAX_THREAD_NUMBER = 25
+    MAX_THREAD_NUMBER = 10
     MAX_FORBIDDEN_RETRIES = 100
     CHANGELOG_GITHUB_TOKEN = "CHANGELOG_GITHUB_TOKEN"
     GH_RATE_LIMIT_EXCEEDED_MSG = "Warning: Can't finish operation: GitHub API rate limit exceeded, changelog may be " \


### PR DESCRIPTION
Solves #656 by reducing the number of concurrent threads.  I don't feel there is a huge performance loss with this change, but generating the log is more reliable.