### PR TITLE
fix #668; Hang on pretty print of options in 1.15.0-rc

### DIFF
--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -105,12 +105,11 @@ module GitHubChangelogGenerator
     def print_options
       return unless self[:verbose]
       Helper.log.info "Using these options:"
-      # pp(censored_values)
-      # For ruby 2.5.0 or avobe
-      censored_values.each{|key, value|
-        print(":", key, "=>", value)
+      # For ruby 2.5.0+
+      censored_values.each do |key, value|
+        print(key.inspect, "=>", value.inspect)
         puts ""
-      }
+      end
       puts ""
     end
 

--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -105,7 +105,12 @@ module GitHubChangelogGenerator
     def print_options
       return unless self[:verbose]
       Helper.log.info "Using these options:"
-      pp(censored_values)
+      # pp(censored_values)
+      # For ruby 2.5.0 or avobe
+      censored_values.each{|key, value|
+        print(":", key, "=>", value)
+        puts ""
+      }
       puts ""
     end
 


### PR DESCRIPTION
This PR fixes a hang(#668) in Ruby 2.5.0 or above.

Test on:
Mac 10.13.6
Ruby 2.4.0, 2.5.0, 2.5.1