### PR TITLE
Fix line break in release summary

### DIFF
--- a/lib/github_changelog_generator/generator/section.rb
+++ b/lib/github_changelog_generator/generator/section.rb
@@ -55,7 +55,7 @@ module GitHubChangelogGenerator
     end
 
     def issue_line_with_body(line, issue)
-      return issue["body"] if @body_only && issue["body"].present?
+      return issue["body"].gsub(/(\r\n|\r|\n)/, "\s\s\n") if @body_only && issue["body"].present?
       return line if !@options[:issue_line_body] || issue["body"].blank?
 
       # get issue body till first line break


### PR DESCRIPTION
This PR fixes line break for markdown in release summary section.

### The issue for release summary
```
![image](https://user-images.githubusercontent.com/12690315/45935880-006a8200-bfeb-11e8-958e-ff742ae66b96.png)
text for summary.

text for summary.
```

### Before:
> ![image](https://user-images.githubusercontent.com/12690315/45935880-006a8200-bfeb-11e8-958e-ff742ae66b96.png)text for summary.
> text for summary.

### After:
> ![image](https://user-images.githubusercontent.com/12690315/45935880-006a8200-bfeb-11e8-958e-ff742ae66b96.png)  
> text for summary.  
>   
> text for summary.