### PR TITLE
Fix warnings in ruby 2.6

### DIFF
--- a/spec/unit/octo_fetcher_spec.rb
+++ b/spec/unit/octo_fetcher_spec.rb
@@ -207,7 +207,7 @@ describe GitHubChangelogGenerator::OctoFetcher do
 
         # Convert times to Time
         expected_issue.each_pair do |k, v|
-          expected_issue[k] = Time.parse(v) if v =~ /^2015-/
+          expected_issue[k] = Time.parse(v) if v.to_s =~ /^2015-/
         end
 
         expect(issues.first).to eq(expected_issue)
@@ -269,7 +269,7 @@ describe GitHubChangelogGenerator::OctoFetcher do
 
         # Convert times to Time
         expected_pr.each_pair do |k, v|
-          expected_pr[k] = Time.parse(v) if v =~ /^2016-01/
+          expected_pr[k] = Time.parse(v) if v.to_s =~ /^2016-01/
         end
 
         expect(pull_requests.first).to eq(expected_pr)
@@ -424,7 +424,7 @@ describe GitHubChangelogGenerator::OctoFetcher do
         # Convert times to Time
         expected_events.map! do |event|
           event.each_pair do |k, v|
-            event[k] = Time.parse(v) if v =~ /^201[56]-/
+            event[k] = Time.parse(v) if v.to_s =~ /^201[56]-/
           end
         end
 


### PR DESCRIPTION
Silences the following warnings: `spec/unit/octo_fetcher_spec.rb:210: warning: deprecated Object#=~ is called on Integer; it always returns nil`