### PR TITLE
Gemspec: drop old setting default_executable

### DIFF
--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -7,7 +7,6 @@ require "github_changelog_generator/version"
 Gem::Specification.new do |spec|
   spec.name               = "github_changelog_generator"
   spec.version            = GitHubChangelogGenerator::VERSION
-  spec.default_executable = "github_changelog_generator"
 
   spec.required_ruby_version = ">= 2.2.2"
   spec.authors = ["Petr Korolev", "Olle Jonsson"]


### PR DESCRIPTION
This PR **fixes a warning** which shows in CI, and when I run `bundle install` in current `master` (with a new-enough RubyGems).

Warning text:

```
NOTE: Gem::Specification#default_executable= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#default_executable= called from /home/circleci/project/github_changelog_generator.gemspec:10.

```
