### PR TITLE
CI: Make RuboCop a required, initial Workflow Job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2.0
+version: 2.1
 
 shared: &shared
   steps:
@@ -14,35 +14,42 @@ shared: &shared
           bundle install --jobs=4 --retry=3 --path vendor/bundle
 
     - run:
-        name: Run Rubocop checks
-        command: |
-          bundle exec rubocop
-
-    - run:
         name: Run tests
         command: |
           bundle exec rspec --color --require spec_helper spec --format progress
 
 jobs:
-  "ruby-2.3":
+  "rubocop":
+    docker:
+      - image: circleci/ruby:2.6.1-node-browsers
+    steps:
+      - checkout
+      - run: bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - run: bundle exec rubocop
+
+  "ruby-23":
     <<: *shared
     docker:
-      - image: circleci/ruby:2.3.7-node-browsers
-  "ruby-2.4":
+      - image: circleci/ruby:2.3.8-node-browsers
+  "ruby-24":
     <<: *shared
     docker:
-      - image: circleci/ruby:2.4.4-node-browsers
-  "ruby-2.5":
+      - image: circleci/ruby:2.4.5-node-browsers
+  "ruby-25":
     <<: *shared
     docker:
-      - image: circleci/ruby:2.5.1-node-browsers
-  "jruby-9.1":
+      - image: circleci/ruby:2.5.3-node-browsers
+  "ruby-26":
+    <<: *shared
+    docker:
+      - image: circleci/ruby:2.6.1-node-browsers
+  "jruby-91":
     <<: *shared
     docker:
       - image: circleci/jruby:9.1-jdk
         environment:
           JRUBY_OPTS: "--debug"
-  "jruby-9.2":
+  "jruby-92":
     <<: *shared
     docker:
       - image: circleci/jruby:9.2-jdk
@@ -53,8 +60,22 @@ workflows:
   version: 2
   build:
     jobs:
-      - "ruby-2.3"
-      - "ruby-2.4"
-      - "ruby-2.5"
-      - "jruby-9.1"
-      - "jruby-9.2"
+      - rubocop
+      - "ruby-23":
+          requires:
+            - rubocop
+      - "ruby-24":
+          requires:
+            - rubocop
+      - "ruby-25":
+          requires:
+            - rubocop
+      - "ruby-26":
+          requires:
+            - rubocop
+      - "jruby-91":
+          requires:
+            - rubocop
+      - "jruby-92":
+          requires:
+            - rubocop


### PR DESCRIPTION
This PR extracts a separate step in the CI workflow: rubocop.

It runs _only_ on Ruby 2.6, and _before_ everything else.

This wins us startup time re JVMs.