### PR TITLE
Use a complete shebang line in git subcommand

### DIFF
--- a/bin/git-generate-changelog
+++ b/bin/git-generate-changelog
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require_relative "../lib/github_changelog_generator"


### PR DESCRIPTION
This PR repairs a defect in the shebang line in the "git subcommand" file.