### PR TITLE
End support for Ruby 2.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   DisplayCopNames: true
   DisplayStyleGuide: true
   Exclude:

--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.name               = "github_changelog_generator"
   spec.version            = GitHubChangelogGenerator::VERSION
 
-  spec.required_ruby_version = ">= 2.2.2"
+  spec.required_ruby_version = ">= 2.3.0"
   spec.authors = ["Petr Korolev", "Olle Jonsson"]
   spec.email = "sky4winder+github_changelog_generator@gmail.com"
 

--- a/lib/github_changelog_generator/generator/entry.rb
+++ b/lib/github_changelog_generator/generator/entry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "github_changelog_generator/generator/section"
 
 module GitHubChangelogGenerator

--- a/lib/github_changelog_generator/generator/section.rb
+++ b/lib/github_changelog_generator/generator/section.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GitHubChangelogGenerator
   # This class generates the content for a single section of a changelog entry.
   # It turns the tagged issues and PRs into a well-formatted list of changes to

--- a/spec/install_gem_in_bundler.gemfile
+++ b/spec/install_gem_in_bundler.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "github_changelog_generator", path: Dir.glob("../pkg/github_changelog_generator-*.gem")[0]


### PR DESCRIPTION
Fixes #687 

- Update required Ruby version in gemspec
- Require Ruby 2.3 in Rubocop.
- (Follow lint rules.)