### PR TITLE
Drop coveralls gem and configuration

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: travis-ci

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ end
 
 group :test do
   gem "codeclimate-test-reporter", "~> 1.0"
-  gem "coveralls", "~>0.8", require: false
   gem "json"
   gem "multi_json"
   gem "rspec", "< 4"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,6 @@
 # limitations under the License.
 #
 require "simplecov"
-require "coveralls"
 require "vcr"
 require "webmock/rspec"
 
@@ -26,10 +25,7 @@ require "webmock/rspec"
 module SpecHelper
 end
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-                                                                 Coveralls::SimpleCov::Formatter,
-                                                                 SimpleCov::Formatter::HTMLFormatter
-                                                               ])
+SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 SimpleCov.start do
   add_filter "gemfiles/"
 end


### PR DESCRIPTION
This PR removes the coveralls integration code which is now unused.