### PR TITLE
Make #fetch_events_async and #fetch_comments_async thread-safe

### DIFF
--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -38,6 +38,7 @@ module GitHubChangelogGenerator
       prepare_cache
       configure_octokit_ssl
       @client = Octokit::Client.new(github_options)
+      @clients = (0...MAX_THREAD_NUMBER).map { Octokit::Client.new(github_options) }
     end
 
     def prepare_cache
@@ -191,10 +192,10 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
       preview = { accept: Octokit::Preview::PREVIEW_TYPES[:project_card_events] }
 
       issues.each_slice(MAX_THREAD_NUMBER) do |issues_slice|
-        issues_slice.each do |issue|
-          threads << Thread.new do
+        issues_slice.each_with_index do |issue, j|
+          threads << Thread.new(@clients[j]) do |client|
             issue["events"] = []
-            iterate_pages(@client, "issue_events", issue["number"], preview) do |new_event|
+            iterate_pages(client, "issue_events", issue["number"], preview) do |new_event|
               issue["events"].concat(new_event)
             end
             issue["events"] = issue["events"].map { |event| stringify_keys_deep(event.to_hash) }
@@ -220,10 +221,10 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
       threads = []
 
       prs.each_slice(MAX_THREAD_NUMBER) do |prs_slice|
-        prs_slice.each do |pr|
-          threads << Thread.new do
+        prs_slice.each_with_index do |pr, i|
+          threads << Thread.new(@clients[i]) do |client|
             pr["comments"] = []
-            iterate_pages(@client, "issue_comments", pr["number"]) do |new_comment|
+            iterate_pages(client, "issue_comments", pr["number"]) do |new_comment|
               pr["comments"].concat(new_comment)
             end
             pr["comments"] = pr["comments"].map { |comment| stringify_keys_deep(comment.to_hash) }


### PR DESCRIPTION
`iterate_page(client, ...)` is called in a thread when getting issue_events.  But `client` is not thread safe.  So sometimes changelog output can be different every time we run `github_changelog_generator`.

This PR fixs it with assigning specified octkit each thread, thanks!