### PR TITLE
Specify activesupport version 5.2.3 

### DIFF
--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency("activesupport")
+  spec.add_runtime_dependency("activesupport", ["~> 5.2.3"])
   spec.add_runtime_dependency("faraday-http-cache")
   spec.add_runtime_dependency("multi_json")
   spec.add_runtime_dependency("octokit", ["~> 4.6"])


### PR DESCRIPTION
github_changelog_generator returns the following error when running it with ruby 2.3.1: 
```
github_changelog_generator was resolved to 1.15.0.pre.rc, which depends on
activesupport was resolved to 6.0.0, which depends on
zeitwerk

Gem::InstallError: zeitwerk requires Ruby version >= 2.4.4.
```

the latest version of activesupport (6.0.0) requires Ruby 2.5.0 or newer -> introduces a breaking change and is no longer compatible with ruby_version < 2.5.0.
In order to keep it working with ruby 2.3.1, I specified the version for activesupport

