### PR TITLE
Allow generator to continue even if any errors encountered in fetch comparison

### DIFF
--- a/lib/github_changelog_generator/argv_parser.rb
+++ b/lib/github_changelog_generator/argv_parser.rb
@@ -205,6 +205,9 @@ module GitHubChangelogGenerator
         opts.on("--[no-]verbose", "Run verbosely. Default is true.") do |v|
           options[:verbose] = v
         end
+        opts.on("--continue-with-errors", "Allow generator to continue even if any errors are encountered in the fetch comparison.") do |continue_with_errors|
+          options[:continue_with_errors] = continue_with_errors
+        end
         opts.on("-v", "--version", "Print version number.") do |_v|
           puts "Version: #{GitHubChangelogGenerator::VERSION}"
           exit

--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -73,7 +73,7 @@ module GitHubChangelogGenerator
         # https://developer.github.com/v3/pulls/#list-pull-requests
         if pr["events"] && (event = pr["events"].find { |e| e["event"] == "merged" })
           # Iterate tags.reverse (oldest to newest) to find first tag of each PR.
-          if (oldest_tag = tags.reverse.find { |tag| tag["shas_in_tag"].include?(event["commit_id"]) })
+          if (oldest_tag = tags.reverse.find { |tag| tag["shas_in_tag"].include?(event["commit_id"]) unless tag["shas_in_tag"].nil? })
             pr["first_occurring_tag"] = oldest_tag["name"]
             found = true
             i += 1

--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -61,7 +61,12 @@ module GitHubChangelogGenerator
     # @param [Hash] event The last merged event information from the pull_request.
     # @return [Boolean] Returns true if tag is associated, false otherwise.
     def add_tag_to_pr(tags, pull_request, event)
-      if (oldest_tag = tags.reverse.find { |tag| tag["shas_in_tag"].include?(event["commit_id"]) unless tag["shas_in_tag"].nil? })
+      if @options[:continue_with_errors]
+        if (oldest_tag = tags.reverse.find { |tag| tag["shas_in_tag"].include?(event["commit_id"]) unless tag["shas_in_tag"].nil? })
+          pull_request["first_occurring_tag"] = oldest_tag["name"]
+          return true
+        end
+      elsif (oldest_tag = tags.reverse.find { |tag| tag["shas_in_tag"].include?(event["commit_id"]) })
         pull_request["first_occurring_tag"] = oldest_tag["name"]
         return true
       end

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -474,6 +474,9 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
       fail_with_message(e, "Exceeded retry limit")
     rescue Octokit::Unauthorized => e
       fail_with_message(e, "Error: wrong GitHub token")
+    rescue StandardError => e
+      Helper.log.error("#{e.class}: #{e.message}")
+      nil
     end
 
     # Presents the exception, and the aborts with the message.

--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -76,6 +76,7 @@ module GitHubChangelogGenerator
       user
       usernames_as_github_logins
       verbose
+      continue_with_errors
     ]
 
     # @param values [Hash]

--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -19,7 +19,7 @@ module GitHubChangelogGenerator
                   between_tags exclude_tags exclude_tags_regex since_tag max_issues
                   github_site github_endpoint simple_list
                   future_release release_branch verbose release_url
-                  base configure_sections add_sections http_cache]
+                  base configure_sections add_sections http_cache
                   base configure_sections add_sections continue_with_errors]
 
     OPTIONS.each do |o|

--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -20,6 +20,7 @@ module GitHubChangelogGenerator
                   github_site github_endpoint simple_list
                   future_release release_branch verbose release_url
                   base configure_sections add_sections http_cache]
+                  base configure_sections add_sections continue_with_errors]
 
     OPTIONS.each do |o|
       attr_accessor o.to_sym

--- a/spec/unit/octo_fetcher_spec.rb
+++ b/spec/unit/octo_fetcher_spec.rb
@@ -587,4 +587,19 @@ describe GitHubChangelogGenerator::OctoFetcher do
       end
     end
   end
+
+  describe "#fetch_compare" do
+    context "with nil compare_data" do
+      it "not raises error" do
+        allow(fetcher).to receive(:check_github_response)
+        expect { fetcher.fetch_compare("a", "b") }.not_to raise_error
+      end
+    end
+    context "with diverged compare_data" do
+      it "raises error" do
+        allow(fetcher).to receive(:check_github_response).and_return("status" => "diverged")
+        expect { fetcher.fetch_compare("a", "b") }.to raise_error(StandardError, /are not related/)
+      end
+    end
+  end
 end

--- a/spec/unit/octo_fetcher_spec.rb
+++ b/spec/unit/octo_fetcher_spec.rb
@@ -587,19 +587,4 @@ describe GitHubChangelogGenerator::OctoFetcher do
       end
     end
   end
-
-  describe "#fetch_compare" do
-    context "with nil compare_data" do
-      it "not raises error" do
-        allow(fetcher).to receive(:check_github_response)
-        expect { fetcher.fetch_compare("a", "b") }.not_to raise_error
-      end
-    end
-    context "with diverged compare_data" do
-      it "raises error" do
-        allow(fetcher).to receive(:check_github_response).and_return("status" => "diverged")
-        expect { fetcher.fetch_compare("a", "b") }.to raise_error(StandardError, /are not related/)
-      end
-    end
-  end
 end


### PR DESCRIPTION
This PR fixes issue: https://github.com/github-changelog-generator/github-changelog-generator/issues/665

There might be a more elegant solution to catch only StandardError instead of the general Exception but I think this should ensure that the change log is generated in most cases even through various errors encountered by the fetcher. 