### PR TITLE
Add no-http-cache option to rake task

### DIFF
--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -19,7 +19,7 @@ module GitHubChangelogGenerator
                   between_tags exclude_tags exclude_tags_regex since_tag max_issues
                   github_site github_endpoint simple_list
                   future_release release_branch verbose release_url
-                  base configure_sections add_sections]
+                  base configure_sections add_sections http_cache]
 
     OPTIONS.each do |o|
       attr_accessor o.to_sym


### PR DESCRIPTION
Simple change to allow to specify the `http_cache` option when using the rake task. This is useful as a workaround for the problem described in #738 but doesn't really fix the issue. Tested locally on my project and it worked.