### PR TITLE
Don't escape special chars when they are in `inline_code`

### DIFF
--- a/lib/github_changelog_generator/generator/section.rb
+++ b/lib/github_changelog_generator/generator/section.rb
@@ -95,7 +95,10 @@ module GitHubChangelogGenerator
       string = string.gsub('\\', '\\\\')
 
       ENCAPSULATED_CHARACTERS.each do |char|
-        string = string.gsub(char, "\\#{char}")
+        # Only replace char with escaped version if it isn't inside backticks (markdown inline code).
+        # This relies on each opening '`' being closed (ie an even number in total).
+        # A char is *outside* backticks if there is an even number of backticks following it.
+        string = string.gsub(%r{#{Regexp.escape(char)}(?=([^`]*`[^`]*`)*[^`]*$)}, "\\#{char}")
       end
 
       string


### PR DESCRIPTION
Fixes #742

This is Work in Progress.  I don't think it's quite right.  I think there are at least edge cases where this isn't good enough. (eg an issue/PR title where one of the special chars occurs twice, once inside inline code and again outside)