### PR TITLE
Bugfix: undefined method line_labels_for

### DIFF
--- a/lib/github_changelog_generator/generator/entry.rb
+++ b/lib/github_changelog_generator/generator/entry.rb
@@ -40,6 +40,15 @@ module GitHubChangelogGenerator
       @content
     end
 
+    def line_labels_for(issue)
+      labels = if @options[:issue_line_labels] == ["ALL"]
+                 issue["labels"]
+               else
+                 issue["labels"].select { |label| @options[:issue_line_labels].include?(label["name"]) }
+               end
+      labels.map { |label| " \[[#{label['name']}](#{label['url'].sub('api.github.com/repos', 'github.com')})\]" }.join("")
+    end
+
     private
 
     # Creates section objects for this entry.
@@ -204,15 +213,6 @@ module GitHubChangelogGenerator
         @sections << merged
       end
       nil
-    end
-
-    def line_labels_for(issue)
-      labels = if @options[:issue_line_labels] == ["ALL"]
-                 issue["labels"]
-               else
-                 issue["labels"].select { |label| @options[:issue_line_labels].include?(label["name"]) }
-               end
-      labels.map { |label| " \[[#{label['name']}](#{label['url'].sub('api.github.com/repos', 'github.com')})\]" }.join("")
     end
   end
 end

--- a/lib/github_changelog_generator/generator/section.rb
+++ b/lib/github_changelog_generator/generator/section.rb
@@ -7,7 +7,7 @@ module GitHubChangelogGenerator
   #
   # @see GitHubChangelogGenerator::Entry
   class Section
-    attr_accessor :name, :prefix, :issues, :labels, :body_only
+    attr_accessor :name, :options, :prefix, :issues, :labels, :body_only
 
     def initialize(opts = {})
       @name = opts[:name]
@@ -49,7 +49,7 @@ module GitHubChangelogGenerator
       encapsulated_title = encapsulate_string issue["title"]
 
       title_with_number = "#{encapsulated_title} [\\##{issue['number']}](#{issue['html_url']})"
-      title_with_number = "#{title_with_number}#{line_labels_for(issue)}" if @options[:issue_line_labels].present?
+      title_with_number = "#{title_with_number}#{Entry.new(options).line_labels_for(issue)}" if @options[:issue_line_labels].present?
       line = issue_line_with_user(title_with_number, issue)
       issue_line_with_body(line, issue)
     end


### PR DESCRIPTION
If you specify option `issue-line-labels` in your `.github_changelog_generator` it will throw:
```
/usr/local/bundle/gems/github_changelog_generator-1.15.0/lib/github_changelog_generator/generator/section.rb:52:in `get_string_for_issue': undefined method `line_labels_for' for #<GitHubChangelogGenerator::Section:0x000055b07a12d628> (NoMethodError)
```

This is fix for it.