### PR TITLE
Fix not parsing body_only param for sections

### DIFF
--- a/lib/github_changelog_generator/generator/entry.rb
+++ b/lib/github_changelog_generator/generator/entry.rb
@@ -72,7 +72,7 @@ module GitHubChangelogGenerator
       end
 
       sections_json.collect do |name, v|
-        Section.new(name: name.to_s, prefix: v["prefix"], labels: v["labels"], options: @options)
+        Section.new(name: name.to_s, prefix: v["prefix"], labels: v["labels"], body_only: v["body_only"], options: @options)
       end
     end
 

--- a/spec/unit/generator/entry_spec.rb
+++ b/spec/unit/generator/entry_spec.rb
@@ -426,6 +426,18 @@ module GitHubChangelogGenerator
             sections_json.shift
           end
         end
+        context "parse also body_only" do
+          let(:sections_string) { "{ \"foo\": { \"prefix\": \"foofix\", \"labels\": [\"test1\", \"test2\"]}, \"bar\": { \"prefix\": \"barfix\", \"labels\": [\"test3\", \"test4\"], \"body_only\": true}}" }
+
+          it "returns correctly constructed sections" do
+            require "json"
+
+            parsed_sections = subject.send(:parse_sections, sections_string)
+
+            expect(parsed_sections[0].body_only).to eq false
+            expect(parsed_sections[1].body_only).to eq true
+          end
+        end
       end
       context "hash" do
         let(:sections_hash) do


### PR DESCRIPTION
Currently `body_only` is not filled into sections properly. This is an issue because if you will use `configure-sections` you will loss "Release summary" section. Because there is no way how to enable body_only param.