### PR TITLE
Update #get_all_tags to only return tags that are for commits on the current branch's history

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     github_changelog_generator (1.15.2)
       activesupport
+      async (>= 1.25.0)
       async-http-faraday
       faraday-http-cache
       multi_json

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -98,7 +98,8 @@ module GitHubChangelogGenerator
     def get_all_tags
       print "Fetching tags...\r" if @options[:verbose]
 
-      check_github_response { github_fetch_tags }
+      all_tags = check_github_response { github_fetch_tags }
+      all_tags.select { |tag| commits.any? { |commit| commit[:sha] == tag["commit"]["sha"] } }
     end
 
     # Returns the number of pages for a API call

--- a/spec/unit/octo_fetcher_spec.rb
+++ b/spec/unit/octo_fetcher_spec.rb
@@ -76,11 +76,17 @@ describe GitHubChangelogGenerator::OctoFetcher do
   end
 
   describe "#get_all_tags" do
+    let(:in_branch_tags) { [{ "commit" => { "sha" => "in-branch" } }] }
+    let(:mock_tags) do
+      in_branch_tags + [{ "commit" => { "sha" => "off-branch" } }]
+    end
+    let(:mock_commits) { [{ sha: "in-branch" }] }
+
     context "when github_fetch_tags returns tags" do
-      it "returns tags" do
-        mock_tags = ["tag"]
+      it "returns tags that are on the current branch" do
         allow(fetcher).to receive(:github_fetch_tags).and_return(mock_tags)
-        expect(fetcher.get_all_tags).to eq(mock_tags)
+        allow(fetcher).to receive(:commits).and_return(mock_commits)
+        expect(fetcher.get_all_tags).to eq(in_branch_tags)
       end
     end
   end


### PR DESCRIPTION
I've encountered a scenario where my repository has multiple branches for different versions of the library. Each major version has a branch that started off as an orphan branch.

This causes issues for me when generating the change log because the `Full Changelog` links sometimes reference a tag from the 2.x branch when I'm generating the change log for the 3.x branch.

This PR addresses that issue by modifying the `#get_all_tags` method to only include tags that are for commits that exist in the current branch's commits.