### PR TITLE
Fixing bug when filtering pull requests without labels

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,10 @@ Metrics/ClassLength:
 Metrics/MethodLength:
     Enabled: false
 
+Metrics/ModuleLength:
+    Exclude:
+      - 'spec/**/*'
+
 Naming/FileName:
     Exclude:
       - 'bin/git-generate-changelog'

--- a/lib/github_changelog_generator/generator/generator_processor.rb
+++ b/lib/github_changelog_generator/generator/generator_processor.rb
@@ -159,12 +159,14 @@ module GitHubChangelogGenerator
     # @param [Array] issues Issues & PRs to filter when without labels
     # @return [Array] Issues & PRs without labels or empty array if
     #                 add_issues_wo_labels or add_pr_wo_labels are false
-    def filter_wo_labels(issues)
-      if (!issues.empty? && issues.first.key?("pull_requests") && options[:add_pr_wo_labels]) || options[:add_issues_wo_labels]
-        issues
-      else
-        issues.select { |issue| issue["labels"].map { |l| l["name"] }.any? }
+    def filter_wo_labels(items)
+      if items.any? && items.first.key?("pull_request")
+        return items if options[:add_pr_wo_labels]
+      elsif options[:add_issues_wo_labels]
+        return items
       end
+      # The default is to filter items without labels
+      items.select { |item| item["labels"].map { |l| l["name"] }.any? }
     end
 
     # @todo Document this

--- a/spec/unit/generator/entry_spec.rb
+++ b/spec/unit/generator/entry_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ModuleLength
 module GitHubChangelogGenerator
   RSpec.describe Entry do
     def label(name)
@@ -757,4 +756,3 @@ module GitHubChangelogGenerator
     end
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/spec/unit/generator/generator_processor_spec.rb
+++ b/spec/unit/generator/generator_processor_spec.rb
@@ -5,82 +5,137 @@ module GitHubChangelogGenerator
     let(:default_options) { GitHubChangelogGenerator::Parser.default_options.merge(verbose: false) }
     let(:options) { {} }
     let(:generator) { described_class.new(default_options.merge(options)) }
-
     let(:bad_label) { { "name" => "BAD" } }
-    let(:bad_issue) { { "labels" => [bad_label] } }
     let(:good_label) { { "name" => "GOOD" } }
-    let(:good_issue) { { "labels" => [good_label] } }
-    let(:unlabeled_issue) { { "labels" => [] } }
-    let(:issues) { [bad_issue, good_issue, unlabeled_issue] }
 
-    describe "#exclude_issues_by_labels" do
-      subject do
-        generator.exclude_issues_by_labels(issues)
-      end
+    describe "pull requests" do
+      let(:bad_pull_request) { { "pull_request" => {}, "labels" => [bad_label] } }
+      let(:good_pull_request) { { "pull_request" => {}, "labels" => [good_label] } }
+      let(:unlabeled_pull_request) { { "pull_request" => {}, "labels" => [] } }
+      let(:pull_requests) { [bad_pull_request, good_pull_request, unlabeled_pull_request] }
 
-      let(:expected_issues) { issues }
+      describe "#filter_wo_labels" do
+        subject do
+          generator.filter_wo_labels(pull_requests)
+        end
 
-      it { is_expected.to eq(expected_issues) }
+        let(:expected_pull_requests) { pull_requests }
 
-      context "when 'exclude_lables' is provided" do
-        let(:options) { { exclude_labels: %w[BAD BOO] } }
-        let(:expected_issues) { [good_issue, unlabeled_issue] }
+        it { is_expected.to eq(expected_pull_requests) }
 
-        it { is_expected.to eq(expected_issues) }
-      end
+        context "when 'add_pr_wo_labels' is false" do
+          let(:options) { { add_pr_wo_labels: false } }
+          let(:expected_pull_requests) { [bad_pull_request, good_pull_request] }
 
-      context "with no option given" do
-        subject(:generator) { described_class.new }
-        it "passes everything through when no option given" do
-          result = generator.exclude_issues_by_labels(issues)
+          it { is_expected.to eq(expected_pull_requests) }
+        end
 
-          expect(result).to eq(issues)
+        context "when 'add_pr_wo_labels' is true" do
+          let(:options) { { add_pr_wo_labels: true } }
+
+          it { is_expected.to eq(expected_pull_requests) }
         end
       end
     end
 
-    describe "#get_filtered_issues" do
-      subject do
-        generator.get_filtered_issues(issues)
-      end
+    describe "issues" do
+      let(:bad_issue) { { "labels" => [bad_label] } }
+      let(:good_issue) { { "labels" => [good_label] } }
+      let(:unlabeled_issue) { { "labels" => [] } }
+      let(:issues) { [bad_issue, good_issue, unlabeled_issue] }
 
-      let(:expected_issues) { issues }
+      describe "#filter_wo_labels" do
+        subject do
+          generator.filter_wo_labels(issues)
+        end
 
-      it { is_expected.to eq(expected_issues) }
-
-      context "when 'exclude_labels' is provided" do
-        let(:options) { { exclude_labels: %w[BAD BOO] } }
-        let(:expected_issues) { [good_issue, unlabeled_issue] }
-
-        it { is_expected.to eq(expected_issues) }
-      end
-
-      context "when 'add_issues_wo_labels' is false" do
-        let(:options) { { add_issues_wo_labels: false } }
-        let(:expected_issues) { [bad_issue, good_issue] }
+        let(:expected_issues) { issues }
 
         it { is_expected.to eq(expected_issues) }
 
-        context "with 'exclude_labels'" do
-          let(:options) { { add_issues_wo_labels: false, exclude_labels: %w[GOOD] } }
-          let(:expected_issues) { [bad_issue] }
+        context "when 'add_issues_wo_labels' is false" do
+          let(:options) { { add_issues_wo_labels: false } }
+          let(:expected_issues) { [bad_issue, good_issue] }
 
           it { is_expected.to eq(expected_issues) }
         end
 
-        context "with 'include_labels'" do
-          let(:options) { { add_issues_wo_labels: false, include_labels: %w[GOOD] } }
-          let(:expected_issues) { [good_issue] }
+        context "when 'add_issues_wo_labels' is true" do
+          let(:options) { { add_issues_wo_labels: true } }
 
           it { is_expected.to eq(expected_issues) }
         end
       end
 
-      context "when 'include_labels' is specified" do
-        let(:options) { { include_labels: %w[GOOD] } }
-        let(:expected_issues) { [good_issue, unlabeled_issue] }
+      describe "#exclude_issues_by_labels" do
+        subject do
+          generator.exclude_issues_by_labels(issues)
+        end
+
+        let(:expected_issues) { issues }
 
         it { is_expected.to eq(expected_issues) }
+
+        context "when 'exclude_labels' is provided" do
+          let(:options) { { exclude_labels: %w[BAD BOO] } }
+          let(:expected_issues) { [good_issue, unlabeled_issue] }
+
+          it { is_expected.to eq(expected_issues) }
+        end
+
+        context "with no option given" do
+          subject(:generator) { described_class.new }
+          it "passes everything through when no option given" do
+            result = generator.exclude_issues_by_labels(issues)
+
+            expect(result).to eq(issues)
+          end
+        end
+      end
+
+      describe "#get_filtered_issues" do
+        subject do
+          generator.get_filtered_issues(issues)
+        end
+
+        let(:expected_issues) { issues }
+
+        it { is_expected.to eq(expected_issues) }
+
+        context "when 'exclude_labels' is provided" do
+          let(:options) { { exclude_labels: %w[BAD BOO] } }
+          let(:expected_issues) { [good_issue, unlabeled_issue] }
+
+          it { is_expected.to eq(expected_issues) }
+        end
+
+        context "when 'add_issues_wo_labels' is false" do
+          let(:options) { { add_issues_wo_labels: false } }
+          let(:expected_issues) { [bad_issue, good_issue] }
+
+          it { is_expected.to eq(expected_issues) }
+
+          context "with 'exclude_labels'" do
+            let(:options) { { add_issues_wo_labels: false, exclude_labels: %w[GOOD] } }
+            let(:expected_issues) { [bad_issue] }
+
+            it { is_expected.to eq(expected_issues) }
+          end
+
+          context "with 'include_labels'" do
+            let(:options) { { add_issues_wo_labels: false, include_labels: %w[GOOD] } }
+            let(:expected_issues) { [good_issue] }
+
+            it { is_expected.to eq(expected_issues) }
+          end
+        end
+
+        context "when 'include_labels' is specified" do
+          let(:options) { { include_labels: %w[GOOD] } }
+          let(:expected_issues) { [good_issue, unlabeled_issue] }
+
+          it { is_expected.to eq(expected_issues) }
+        end
       end
     end
   end


### PR DESCRIPTION
The `filter_wo_labels` method is excluding pull requests that do not have labels even though the `:add_pr_wo_labels`/`pr-wo-labels` option is set to true.

This is due to an incorrect key being used to identify that the object being considered is a pull request.