### PR TITLE
feat: support relative tags with since_tag option

### DIFF
--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -35,7 +35,12 @@ module GitHubChangelogGenerator
         tag = section_tags[i]
 
         # Don't create section header for the "since" tag
-        next if since_tag && tag["name"] == since_tag
+        if since_tag
+            if since_tag.match('TAG~(\d+)')
+              next if i == $1.to_i - 1
+            end
+            next if tag["name"] == since_tag
+        end
 
         # Don't create a section header for the first tag in between_tags
         next if options[:between_tags] && tag == section_tags.last
@@ -127,6 +132,10 @@ module GitHubChangelogGenerator
       filtered_tags = all_tags
       tag = since_tag
       if tag
+        if tag.match('TAG~([1-9]+)')
+          return all_tags[0, $1.to_i]
+        end
+
         if all_tags.map { |t| t["name"] }.include? tag
           idx = all_tags.index { |t| t["name"] == tag }
           filtered_tags = if idx

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -187,6 +187,14 @@ describe GitHubChangelogGenerator::Generator do
           let(:generator) { GitHubChangelogGenerator::Generator.new(since_tag: "1") }
           it { is_expected.to match_array(tags_from_strings(%w[1])) }
         end
+        context "with since tag set to be the last tag" do
+          let(:generator) { GitHubChangelogGenerator::Generator.new(since_tag: "TAG~1") }
+          it { is_expected.to match_array(tags_from_strings(%w[1])) }
+        end
+        context "with since tag set to be the last two tags" do
+          let(:generator) { GitHubChangelogGenerator::Generator.new(since_tag: "TAG~2") }
+          it { is_expected.to match_array(tags_from_strings(%w[1 2])) }
+        end
       end
 
       context "with invalid since tag" do


### PR DESCRIPTION
It's convenient if we can specify relative tags with `since_tags` option,
such as `TAG~1` for since last tag, `TAG~2` for since last 2 tags and so on.

Refer to Issue #775 for details.