### PR TITLE
fix: disable preview api warning from octokit.rb

### DIFF
--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -187,12 +187,14 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
     def fetch_events_async(issues)
       i       = 0
       threads = []
+      # Add accept option explicitly for disabling the warning of preview API.
+      preview = { accept: Octokit::Preview::PREVIEW_TYPES[:project_card_events] }
 
       issues.each_slice(MAX_THREAD_NUMBER) do |issues_slice|
         issues_slice.each do |issue|
           threads << Thread.new do
             issue["events"] = []
-            iterate_pages(@client, "issue_events", issue["number"]) do |new_event|
+            iterate_pages(@client, "issue_events", issue["number"], preview) do |new_event|
               issue["events"].concat(new_event)
             end
             issue["events"] = issue["events"].map { |event| stringify_keys_deep(event.to_hash) }


### PR DESCRIPTION
octokit outputs warning message for preview API such as `issue_events`,
which is annoying. We can explicitly add the accept option when
calling the API to disable it.

Refer to `lib/octokit/preview.rb` in octokit for more information.

fix: #773