### PR TITLE
CI: JRuby 9.1 support: hold ActiveSupport at 5.x, introduce gemfiles/ directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
       - image: circleci/jruby:9.1-jdk
         environment:
           JRUBY_OPTS: "--debug"
+          BUNDLE_GEMFILE: "gemfiles/Gemfile_jruby_91"
   "jruby-92":
     <<: *shared
     docker:

--- a/gemfiles/Gemfile_jruby_91
+++ b/gemfiles/Gemfile_jruby_91
@@ -1,0 +1,3 @@
+eval_gemfile "../Gemfile"
+
+gem "activesupport", "< 6"

--- a/gemfiles/Gemfile_jruby_91.lock
+++ b/gemfiles/Gemfile_jruby_91.lock
@@ -1,0 +1,138 @@
+PATH
+  remote: ..
+  specs:
+    github_changelog_generator (1.15.1)
+      activesupport
+      faraday-http-cache
+      multi_json
+      octokit (~> 4.6)
+      rainbow (>= 2.2.1)
+      rake (>= 10.0)
+      retriable (~> 3.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.2.4.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.0)
+    backports (3.17.0)
+    bump (0.9.0)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    codeclimate-test-reporter (1.0.7)
+      simplecov
+    concurrent-ruby (1.1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.3)
+    docile (1.3.2)
+    faraday (0.17.3)
+      multipart-post (>= 1.2, < 3)
+    faraday-http-cache (2.1.0)
+      faraday (~> 0.8)
+    ffi (1.12.2-java)
+    hashdiff (1.0.1)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
+    iniparse (1.5.0)
+    jaro_winkler (1.5.4-java)
+    json (2.3.0-java)
+    minitest (5.14.0)
+    multi_json (1.14.1)
+    multipart-post (2.1.1)
+    octokit (4.18.0)
+      faraday (>= 0.9)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    overcommit (0.47.0)
+      childprocess (~> 0.6, >= 0.6.3)
+      iniparse (~> 1.4)
+    parallel (1.19.1)
+    parser (2.7.1.0)
+      ast (~> 2.4.0)
+    public_suffix (4.0.4)
+    rainbow (3.0.0)
+    rake (13.0.1)
+    retriable (3.1.2)
+    rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
+    rubocop (0.81.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rexml
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-performance (1.5.2)
+      rubocop (>= 0.71.0)
+    ruby-progressbar (1.10.1)
+    safe_yaml (1.0.5)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    thread_safe (0.3.6-java)
+    tty-color (0.5.1)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
+    unicode-display_width (1.7.0)
+    vcr (5.1.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    yard (0.9.24)
+    yard-junk (0.0.7)
+      backports
+      rainbow
+      tty-color
+      yard
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  activesupport (< 6)
+  bump
+  bundler
+  codeclimate-test-reporter (~> 1.0)
+  github_changelog_generator!
+  json
+  multi_json
+  overcommit (>= 0.31)
+  rake
+  rspec (< 4)
+  rubocop (>= 0.50)
+  rubocop-performance
+  simplecov (~> 0.10)
+  vcr
+  webmock
+  yard-junk
+
+RUBY VERSION
+   ruby 2.3.3p0 (jruby 9.1.17.0)
+
+BUNDLED WITH
+   2.1.4


### PR DESCRIPTION
This PR adds a `gemfiles/` directory to hold specific gemfiles to support older versions of Ruby, which may not be able run latest ActiveSupport.

Note: This fixes the JRuby 9.1 build.

## Solution

- Add a JRuby 9.1 configuration file which holds ActiveSupport at `< 6.0`
- Point to this configuration file using a Bundler ENV variable in the CircleCI configuration

## Background

JRuby 9.1 has this description: `ruby 2.3.3p0 (jruby 9.1.17.0)`

Example of failed build: https://app.circleci.com/pipelines/github/github-changelog-generator/github-changelog-generator/88/workflows/210ce33f-b78b-47c1-a250-8e038c83cb78/jobs/1351