### PR TITLE
CI: Ruby 2.3, Ruby 2.4 hold at ActiveSupport < 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,8 @@ shared: &shared
     - run:
         name: Install dependencies
         command: |
-          bundle install --jobs=4 --retry=3 --path vendor/bundle
+          gem i bundler -v'> 2'
+          bundle install --jobs=4 --retry=3
 
     - run:
         name: Run rubocop
@@ -28,23 +29,32 @@ jobs:
     <<: *shared
     docker:
       - image: circleci/ruby:2.3-node-browsers
+        environment:
+          BUNDLE_PATH: vendor/bundle
   "ruby-24":
     <<: *shared
     docker:
       - image: circleci/ruby:2.4-node-browsers
+        environment:
+          BUNDLE_PATH: vendor/bundle
   "ruby-25":
     <<: *shared
     docker:
       - image: circleci/ruby:2.5-node-browsers
+        environment:
+          BUNDLE_PATH: vendor/bundle
   "ruby-26":
     <<: *shared
     docker:
       - image: circleci/ruby:2.6-node-browsers
+        environment:
+          BUNDLE_PATH: vendor/bundle
   "jruby-91":
     <<: *shared
     docker:
       - image: circleci/jruby:9.1-jdk
         environment:
+          BUNDLE_PATH: vendor/bundle
           JRUBY_OPTS: "--debug"
           BUNDLE_GEMFILE: "gemfiles/Gemfile_jruby_91"
   "jruby-92":
@@ -52,6 +62,7 @@ jobs:
     docker:
       - image: circleci/jruby:9.2-jdk
         environment:
+          BUNDLE_PATH: vendor/bundle
           JRUBY_OPTS: "--debug"
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,14 @@ jobs:
     docker:
       - image: circleci/ruby:2.3-node-browsers
         environment:
+          BUNDLE_GEMFILE: "gemfiles/Gemfile_ruby_23"
           BUNDLE_PATH: vendor/bundle
   "ruby-24":
     <<: *shared
     docker:
       - image: circleci/ruby:2.4-node-browsers
         environment:
+          BUNDLE_GEMFILE: "gemfiles/Gemfile_ruby_24"
           BUNDLE_PATH: vendor/bundle
   "ruby-25":
     <<: *shared

--- a/gemfiles/Gemfile_ruby_23
+++ b/gemfiles/Gemfile_ruby_23
@@ -1,0 +1,3 @@
+eval_gemfile "../Gemfile"
+
+gem "activesupport", "< 6"

--- a/gemfiles/Gemfile_ruby_24
+++ b/gemfiles/Gemfile_ruby_24
@@ -1,0 +1,3 @@
+eval_gemfile "../Gemfile"
+
+gem "activesupport", "< 6"


### PR DESCRIPTION
This PR:

- uses Bundler 2 for all interactions
- avoids a Bundler deprecation
- creates specific Gemfiles in the `gemfiles/` directory, to make builds pass on Ruby 2.3, Ruby 2.4