### PR TITLE
chore: RuboCop: Add more Cop names as enabled

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,23 +15,23 @@ Metrics/LineLength:
 Performance/RegexpMatch:
   Enabled: false
 
-#http://viget.com/extend/just-use-double-quoted-ruby-strings
+# http://viget.com/extend/just-use-double-quoted-ruby-strings
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-    Enabled: false
+  Enabled: false
 
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-    Enabled: false
+  Enabled: false
 
 Naming/FileName:
-    Exclude:
-      - 'bin/git-generate-changelog'
+  Exclude:
+    - 'bin/git-generate-changelog'
 
-#TODOS
+# TODOS
 # Offense count: 14
 Metrics/AbcSize:
   Enabled: false
@@ -64,7 +64,7 @@ Style/RegexpLiteral:
   Enabled: false
 
 Style/MutableConstant:
-    Enabled: false
+  Enabled: false
 
 # "Use idx.positive? instead of idx > 0."
 Style/NumericPredicate:
@@ -88,3 +88,18 @@ Style/FormatStringToken:
 Style/MixinUsage:
   Exclude:
     - lib/github_changelog_generator/task.rb
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true


### PR DESCRIPTION
This PR adds a few as-yet unconfigured Cop rules to the RuboCop configuration file.