### PR TITLE
(refactor) Reuse an Entry instance in Section; change accessors to readers

### DIFF
--- a/lib/github_changelog_generator/generator/section.rb
+++ b/lib/github_changelog_generator/generator/section.rb
@@ -32,6 +32,7 @@ module GitHubChangelogGenerator
       @issues = opts[:issues] || []
       @options = opts[:options] || Options.new({})
       @body_only = opts[:body_only] || false
+      @entry = Entry.new(options)
     end
 
     # Returns the content of a section.
@@ -65,7 +66,7 @@ module GitHubChangelogGenerator
       encapsulated_title = encapsulate_string issue["title"]
 
       title_with_number = "#{encapsulated_title} [\\##{issue['number']}](#{issue['html_url']})"
-      title_with_number = "#{title_with_number}#{Entry.new(options).line_labels_for(issue)}" if @options[:issue_line_labels].present?
+      title_with_number = "#{title_with_number}#{@entry.line_labels_for(issue)}" if @options[:issue_line_labels].present?
       line = issue_line_with_user(title_with_number, issue)
       issue_line_with_body(line, issue)
     end

--- a/lib/github_changelog_generator/generator/section.rb
+++ b/lib/github_changelog_generator/generator/section.rb
@@ -7,7 +7,23 @@ module GitHubChangelogGenerator
   #
   # @see GitHubChangelogGenerator::Entry
   class Section
-    attr_accessor :name, :options, :prefix, :issues, :labels, :body_only
+    # @return [String]
+    attr_accessor :name
+
+    # @return [String] a merge prefix, or an issue prefix
+    attr_reader :prefix
+
+    # @return [Array<Hash>]
+    attr_reader :issues
+
+    # @return [Array<String>]
+    attr_reader :labels
+
+    # @return [Boolean]
+    attr_reader :body_only
+
+    # @return [Options]
+    attr_reader :options
 
     def initialize(opts = {})
       @name = opts[:name]


### PR DESCRIPTION
I commented on #753, and said we could do those feedback items later.

Here they are. Small things:

- remove the writers which were exposed and never used
- create the `Entry` needed for a `Section` in the constructor - and reuse it