### PR TITLE
Section: Split quicker on newline

### DIFF
--- a/lib/github_changelog_generator/generator/section.rb
+++ b/lib/github_changelog_generator/generator/section.rb
@@ -69,7 +69,7 @@ module GitHubChangelogGenerator
     end
 
     def body_till_first_break(body)
-      body.split(/\n/).first
+      body.split(/\n/, 2).first
     end
 
     def issue_line_with_user(line, issue)


### PR DESCRIPTION
This PR adds "split into 2 groups" to a string-splitting method: 

  - we only need to get 1 group
  - so we can ask String#split() to give us two groups