### PR TITLE
Don't escape special chars when they are in `inline_code` (carried from #743)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - 'vendor/**/*'
     - 'gemfiles/**/*'
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Performance/RegexpMatch:

--- a/lib/github_changelog_generator/generator/section.rb
+++ b/lib/github_changelog_generator/generator/section.rb
@@ -112,7 +112,10 @@ module GitHubChangelogGenerator
       string = string.gsub('\\', '\\\\')
 
       ENCAPSULATED_CHARACTERS.each do |char|
-        string = string.gsub(char, "\\#{char}")
+        # Only replace char with escaped version if it isn't inside backticks (markdown inline code).
+        # This relies on each opening '`' being closed (ie an even number in total).
+        # A char is *outside* backticks if there is an even number of backticks following it.
+        string = string.gsub(%r{#{Regexp.escape(char)}(?=([^`]*`[^`]*`)*[^`]*$)}, "\\#{char}")
       end
 
       string

--- a/spec/unit/generator/section_spec.rb
+++ b/spec/unit/generator/section_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module GitHubChangelogGenerator
+  RSpec.describe Section do
+    let(:options) { {} }
+    subject(:section) { described_class.new(options) }
+
+    describe "#encapsulate_string" do
+      let(:string) { "" }
+
+      context "with the empty string" do
+        it "returns the string" do
+          expect(section.send(:encapsulate_string, string)).to eq string
+        end
+      end
+
+      context "with a string with an escape-needing character in it" do
+        let(:string) { "<Inside> and outside" }
+
+        it "returns the string escaped" do
+          expect(section.send(:encapsulate_string, string)).to eq '\\<Inside\\> and outside'
+        end
+      end
+
+      context "with a backticked string with an escape-needing character in it" do
+        let(:string) { 'back `\` slash' }
+
+        it "returns the string" do
+          expect(section.send(:encapsulate_string, string)).to eq 'back `\` slash'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR carries @alexjfisher's #743. Thanks!

Fixes #742

Closes #743 
