### PR TITLE
CI: Use the Ruby orb, parameterize a matrix job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,6 @@ workflows:
       - test:
           matrix:
             parameters:
-              tag: ["ruby:2.5-node-browsers", "ruby:2.6-node-browsers", "ruby:2.7-node-browsers"]
+              tag: ["2.5-node-browsers", "2.6-node-browsers", "2.7-node-browsers"]
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       BUNDLE_PATH: vendor/bundle
       JRUBY_OPTS: "--debug"
     docker:
-      - image: circleci/jruby:9.2-jdk
+      - image: circleci/jruby:9.2
     <<: *shared_steps
 
 workflows:
@@ -59,6 +59,6 @@ workflows:
       - test:
           matrix:
             parameters:
-              tag: ["2.5-node-browsers", "2.6-node-browsers", "2.7-node-browsers"]
+              tag: ["2.5", "2.6", "2.7"]
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       - run: ruby -v
       - checkout
       - ruby/load-cache
+      - run: gem install bundler:2.1.4
       - ruby/install-deps
       - ruby/save-cache
       - ruby/run-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,16 @@
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
 version: 2.1
+orbs:
+  ruby: circleci/ruby@0.2.2
 
 shared: &shared
+  environment:
+    BUNDLE_PATH: vendor/bundle
   steps:
     - checkout
 
-    - run:
-        name: Install dependencies
-        command: |
-          gem i bundler -v'> 2'
-          bundle install --jobs=4 --retry=3
+    - ruby/install-deps
 
     - run:
         name: Run rubocop
@@ -29,20 +29,15 @@ jobs:
     <<: *shared
     docker:
       - image: circleci/ruby:2.5-node-browsers
-        environment:
-          BUNDLE_PATH: vendor/bundle
   "ruby-26":
     <<: *shared
     docker:
       - image: circleci/ruby:2.6-node-browsers
-        environment:
-          BUNDLE_PATH: vendor/bundle
   "jruby-92":
     <<: *shared
     docker:
       - image: circleci/jruby:9.2-jdk
         environment:
-          BUNDLE_PATH: vendor/bundle
           JRUBY_OPTS: "--debug"
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,10 @@ jobs:
     environment:
       BUNDLE_PATH: vendor/bundle
       JRUBY_OPTS: "--debug"
-    executor: ruby/default
-    parallelism: 4
+    executor:
+      ruby/default:
+        tag: << parameters.tag >>
+    parallelism: 1
     steps:
       - run: ruby -v
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,15 @@ orbs:
   ruby: circleci/ruby@0.2.2
 
 jobs:
+  lint:
+    environment:
+      BUNDLE_PATH: vendor/bundle
+    executor: ruby/default
+    steps:
+      - checkout
+      - ruby/install-deps
+      - run: bundle exec rubocop
+
   test:
     parameters:
       tag:
@@ -18,17 +27,13 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-
-      - run:
-          name: Run rubocop
-          command: |
-            bundle exec rubocop
       - ruby/run-tests
 
 workflows:
   version: 2
   build:
     jobs:
+      - lint
       - test:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       BUNDLE_PATH: vendor/bundle
       JRUBY_OPTS: "--debug"
     docker:
-      - image: circleci/ruby:<< parameters.tag >>
+      - image: circleci/<< parameters.tag >>
     parallelism: 1
     steps:
       - run: ruby -v
@@ -44,4 +44,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              tag: ["2.5-node-browsers", "2.6-node-browsers", "2.7-node-browsers", "jruby-9.2-jdk"]
+              tag: ["ruby:2.5-node-browsers", "ruby:2.6-node-browsers", "ruby:2.7-node-browsers", "jruby:9.2-jdk"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,8 @@ jobs:
     environment:
       BUNDLE_PATH: vendor/bundle
       JRUBY_OPTS: "--debug"
-    executor:
-      ruby/default:
-        tag: << parameters.tag >>
+    docker:
+      - image: circleci/ruby:<< parameters.tag >>
     parallelism: 1
     steps:
       - run: ruby -v
@@ -45,4 +44,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              tag: ["2.5-node-browsers", "2.6-node-browsers", "2.7-node-browsers"]
+              tag: ["2.5-node-browsers", "2.6-node-browsers", "2.7-node-browsers", "jruby-9.2-jdk"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,16 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@0.2.2
 
+shared_steps: &shared_steps
+  steps:
+    - run: ruby -v
+    - checkout
+    - ruby/load-cache
+    - run: gem install bundler:2.1.4
+    - ruby/install-deps
+    - ruby/save-cache
+    - ruby/run-tests
+
 jobs:
   lint:
     environment:
@@ -24,25 +34,31 @@ jobs:
         type: string
     environment:
       BUNDLE_PATH: vendor/bundle
+    executor:
+      name: ruby/default
+      tag: << parameters.tag >>
+    parallelism: 1
+    <<: *shared_steps
+
+  test_jruby:
+    environment:
+      BUNDLE_PATH: vendor/bundle
       JRUBY_OPTS: "--debug"
     docker:
-      - image: circleci/<< parameters.tag >>
-    parallelism: 1
-    steps:
-      - run: ruby -v
-      - checkout
-      - ruby/load-cache
-      - run: gem install bundler:2.1.4
-      - ruby/install-deps
-      - ruby/save-cache
-      - ruby/run-tests
+      - image: circleci/jruby:9.2-jdk
+    <<: *shared_steps
 
 workflows:
   version: 2
   build:
     jobs:
       - lint
+      - test_jruby:
+          requires:
+            - lint
       - test:
           matrix:
             parameters:
-              tag: ["ruby:2.5-node-browsers", "ruby:2.6-node-browsers", "ruby:2.7-node-browsers", "jruby:9.2-jdk"]
+              tag: ["ruby:2.5-node-browsers", "ruby:2.6-node-browsers", "ruby:2.7-node-browsers"]
+          requires:
+            - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,44 +6,30 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@0.2.2
 
-shared: &shared
-  environment:
-    BUNDLE_PATH: vendor/bundle
-  steps:
-    - checkout
-
-    - ruby/install-deps
-
-    - run:
-        name: Run rubocop
-        command: |
-          bundle exec rubocop
-
-    - run:
-        name: Run tests
-        command: |
-          bundle exec rspec --color --require spec_helper spec --format progress
-
 jobs:
-  "ruby-25":
-    <<: *shared
-    docker:
-      - image: circleci/ruby:2.5-node-browsers
-  "ruby-26":
-    <<: *shared
-    docker:
-      - image: circleci/ruby:2.6-node-browsers
-  "jruby-92":
-    <<: *shared
-    docker:
-      - image: circleci/jruby:9.2-jdk
-        environment:
-          JRUBY_OPTS: "--debug"
+  test:
+    parameters:
+      tag:
+        type: string
+    environment:
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--debug"
+    executor: ruby/default
+    steps:
+      - checkout
+      - ruby/install-deps
+
+      - run:
+          name: Run rubocop
+          command: |
+            bundle exec rubocop
+      - ruby/run-tests
 
 workflows:
   version: 2
   build:
     jobs:
-      - "ruby-25"
-      - "ruby-26"
-      - "jruby-92"
+      - test:
+          matrix:
+            parameters:
+              tag: ["2.5-node-browsers", "2.6-node-browsers", "2.7-node-browsers"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,9 @@ jobs:
       BUNDLE_PATH: vendor/bundle
     executor: ruby/default
     steps:
+      - run: ruby -v
       - checkout
+      - ruby/load-cache
       - ruby/install-deps
       - run: bundle exec rubocop
 
@@ -25,8 +27,11 @@ jobs:
       JRUBY_OPTS: "--debug"
     executor: ruby/default
     steps:
+      - run: ruby -v
       - checkout
+      - ruby/load-cache
       - ruby/install-deps
+      - ruby/save-cache
       - ruby/run-tests
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
       BUNDLE_PATH: vendor/bundle
       JRUBY_OPTS: "--debug"
     executor: ruby/default
+    parallelism: 4
     steps:
       - run: ruby -v
       - checkout

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :test do
   gem "json"
   gem "multi_json"
   gem "rspec", "< 4"
+  gem "rspec_junit_formatter"
   gem "simplecov", "~>0.10", require: false
   gem "vcr"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     iniparse (1.5.0)
+    jaro_winkler (1.5.4)
     json (2.3.0)
     minitest (5.14.0)
     multi_json (1.14.1)
@@ -99,7 +100,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.83.0)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
@@ -149,6 +153,7 @@ DEPENDENCIES
   overcommit (>= 0.31)
   rake
   rspec (< 4)
+  rspec_junit_formatter
   rubocop (>= 0.50)
   rubocop-performance
   simplecov (~> 0.10)


### PR DESCRIPTION
This PR is an attempt to begin using CircleCI's Orb for Ruby, to make the configuration smaller and more vanilla.

Result:

- we have an actual matrix, configured using a parameter list
- we have separated out linting to its own step (run in 2.7)
- we have a shared "steps" list
- we use Ruby Orb 1.0.0

TODO after review:

- smash together all the commits
- disable the now-unused CI jobs from the Settings / Branch protection (so that the build _can_ pass)
- perhaps find a JRuby orb, too?