### PR TITLE
More concurrency

### DIFF
--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency("activesupport")
+  spec.add_runtime_dependency("async", ">= 1.25.0")
   spec.add_runtime_dependency("async-http-faraday")
   spec.add_runtime_dependency("faraday-http-cache")
   spec.add_runtime_dependency("multi_json")

--- a/lib/github_changelog_generator/generator/generator.rb
+++ b/lib/github_changelog_generator/generator/generator.rb
@@ -49,18 +49,21 @@ module GitHubChangelogGenerator
     # @return [String] Generated changelog file
     def compound_changelog
       @options.load_custom_ruby_files
-      fetch_and_filter_tags
-      fetch_issues_and_pr
 
-      log = if @options[:unreleased_only]
-              generate_entry_between_tags(@filtered_tags[0], nil)
-            else
-              generate_entries_for_all_tags
-            end
-      log += File.read(@options[:base]) if File.file?(@options[:base])
-      log = remove_old_fixed_string(log)
-      log = insert_fixed_string(log)
-      @log = log
+      Sync do
+        fetch_and_filter_tags
+        fetch_issues_and_pr
+
+        log = if @options[:unreleased_only]
+                generate_entry_between_tags(@filtered_tags[0], nil)
+              else
+                generate_entries_for_all_tags
+              end
+        log += File.read(@options[:base]) if File.file?(@options[:base])
+        log = remove_old_fixed_string(log)
+        log = insert_fixed_string(log)
+        @log = log
+      end
     end
 
     private

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -227,8 +227,6 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
 
         # to clear line from prev print
         print_empty_line
-
-        client.agent.close
       end
 
       Helper.log.info "Fetching events for issues and PR: #{i}"
@@ -256,8 +254,6 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
         end
 
         barrier.wait
-
-        client.agent.close
       end
 
       nil
@@ -317,7 +313,6 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
           end
 
           barrier.wait
-          client.agent.close
 
           @commits.sort! do |b, a|
             a[:commit][:author][:date] <=> b[:commit][:author][:date]


### PR DESCRIPTION
Calling `#close` is no longer required, because the connection pool uses a transient task and automatically closes when going out of scope. This PR removes `#close` and also adds a top level scope around the generator, so that persistent connections can be reused between different parts of `OctoFetcher`.