### PR TITLE
Use UTC for future release date

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     github_changelog_generator (1.15.2)
       activesupport
+      async (>= 1.25.0)
       async-http-faraday
       faraday-http-cache
       multi_json

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -83,7 +83,7 @@ module GitHubChangelogGenerator
     # @return [Array] link, name and time of the tag
     def detect_link_tag_time(newer_tag)
       # if tag is nil - set current time
-      newer_tag_time = newer_tag.nil? ? Time.new : get_time_of_tag(newer_tag)
+      newer_tag_time = newer_tag.nil? ? Time.new.getutc : get_time_of_tag(newer_tag)
 
       # if it's future release tag - set this value
       if newer_tag.nil? && options[:future_release]

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -13,6 +13,33 @@ describe GitHubChangelogGenerator::Generator do
     end
   end
 
+  describe "#detect_link_tag_time" do
+    let(:newer_tag) { nil }
+
+    let(:default_options) { GitHubChangelogGenerator::Parser.default_options.merge(verbose: false) }
+    let(:options) do
+      {
+        future_release: "2.0.0"
+      }
+    end
+    let(:generator) { described_class.new(default_options.merge(options)) }
+
+    subject do
+      generator.detect_link_tag_time(newer_tag)
+    end
+
+    context "When the local date is not the same as the UTC date" do
+      before do
+        # 2020-12-27T17:00:00-10:00 is 2020-12-28T03:00:00Z.
+        # GitHub API date & time use UTC, so this instant when converted as a
+        # date should be 2020-12-28.
+        expect(Time).to receive(:new).and_return(Time.new(2020, 12, 27, 17, 0, 0, "-10:00"))
+      end
+
+      it { is_expected.to eq(["2.0.0", "2.0.0", Time.gm(2020, 12, 28, 3)]) }
+    end
+  end
+
   describe "#tag_section_mapping" do
     let(:all_tags) { tags_from_strings(%w[8 7 6 5 4 3 2 1]) }
     let(:sorted_tags) { all_tags }


### PR DESCRIPTION
When using future releases, the current local date is writen in the
generated CHANGELOG.  This is usualy done as part of releasing a new
version, that is a few seconds before a that version is tagged and
that tag is pushed to GitHub.

On next version bump, that previous tag exist and it's date is read from
GitHub which provide this information in Coordinated Universal Time
(UTC).

Depending on the time-zone of the user, the date of these two Ruby Time
objects may be different, leading to an unexpected change in the
previous entry of the CHANGELOG.

To avoid this, convert the local time to UTC when we do not have an
actual tag time to use.