### PR TITLE
Add --include-tags-regex option.

### DIFF
--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -11,7 +11,8 @@ module GitHubChangelogGenerator
       fetch_tags_dates(all_tags) # Creates a Hash @tag_times_hash
       all_sorted_tags = sort_tags_by_date(all_tags)
 
-      @sorted_tags   = filter_excluded_tags(all_sorted_tags)
+      @sorted_tags   = filter_included_tags(all_sorted_tags)
+      @sorted_tags   = filter_excluded_tags(@sorted_tags)
       @filtered_tags = get_filtered_tags(@sorted_tags)
 
       # Because we need to properly create compare links, we need a sorted list
@@ -159,6 +160,17 @@ module GitHubChangelogGenerator
         end
       end
       filtered_tags
+    end
+
+    # @param [Array] all_tags all tags
+    # @return [Array] filtered tags according to :include_tags_regex option
+    def filter_included_tags(all_tags)
+      if options[:include_tags_regex]
+        regex = Regexp.new(options[:include_tags_regex])
+        all_tags.select { |tag| regex =~ tag["name"] }
+      else
+        all_tags
+      end
     end
 
     # @param [Array] all_tags all tags

--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -45,6 +45,7 @@ module GitHubChangelogGenerator
       header
       http_cache
       include_labels
+      include_tags_regex
       issue_prefix
       issue_line_labels
       issue_line_body

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -160,6 +160,9 @@ module GitHubChangelogGenerator
         opts.on("--issue-line-labels x,y,z", Array, 'The specified labels will be shown in brackets next to each matching issue. Use "ALL" to show all labels. Default is [].') do |list|
           options[:issue_line_labels] = list
         end
+        opts.on("--include-tags-regex [REGEX]", "Apply a regular expression on tag names so that they can be included, for example: --include-tags-regex \".*\+\d{1,}\".") do |last|
+          options[:include_tags_regex] = last
+        end
         opts.on("--exclude-tags  x,y,z", Array, "Changelog will exclude specified tags") do |list|
           options[:exclude_tags] = list
         end

--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -15,7 +15,7 @@ module GitHubChangelogGenerator
                   pulls filter_issues_by_milestone author
                   unreleased_only unreleased unreleased_label
                   compare_link include_labels exclude_labels
-                  bug_labels enhancement_labels
+                  bug_labels enhancement_labels include_tags_regex
                   between_tags exclude_tags exclude_tags_regex since_tag max_issues
                   github_site github_endpoint simple_list
                   future_release release_branch verbose release_url

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -157,6 +157,22 @@ describe GitHubChangelogGenerator::Generator do
     end
   end
 
+  describe "#filter_included_tags_regex" do
+    subject { generator.filter_included_tags(tags_from_strings(%w[1 2 3])) }
+
+    context "with matching regex" do
+      let(:generator) { GitHubChangelogGenerator::Generator.new(include_tags_regex: "[23]") }
+      it { is_expected.to be_a Array }
+      it { is_expected.to match_array(tags_from_strings(%w[2 3])) }
+    end
+
+    context "with non-matching regex" do
+      let(:generator) { GitHubChangelogGenerator::Generator.new(include_tags_regex: "[45]") }
+      it { is_expected.to be_a Array }
+      it { is_expected.to match_array(tags_from_strings(%w[])) }
+    end
+  end
+
   describe "#filter_excluded_tags" do
     subject { generator.filter_excluded_tags(tags_from_strings(%w[1 2 3])) }
 


### PR DESCRIPTION
For my usecase, excluding tags would be too cumbersome. This PR allows for the ability to do things like `--include-tags-regex='v0.[56]'` to focus on a certain range, or `--include-tags-regex='^v\d+.\d+.\d+$'` to exclude all tags with `-develop` or `-rc` or similar suffixes.