### PR TITLE
When tags are excluded, do not include those tags in diff links.

### DIFF
--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -13,13 +13,7 @@ module GitHubChangelogGenerator
 
       @sorted_tags   = filter_excluded_tags(all_sorted_tags)
       @filtered_tags = get_filtered_tags(@sorted_tags)
-
-      # Because we need to properly create compare links, we need a sorted list
-      # of all filtered tags (including the excluded ones). We'll exclude those
-      # tags from section headers inside the mapping function.
-      section_tags = get_filtered_tags(all_sorted_tags)
-
-      @tag_section_mapping = build_tag_section_mapping(section_tags, @filtered_tags)
+      @tag_section_mapping = build_tag_section_mapping(@filtered_tags, @filtered_tags)
 
       @filtered_tags
     end

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -84,10 +84,10 @@ describe GitHubChangelogGenerator::Generator do
     shared_examples_for "a changelog with some exclusions" do
       let(:expected_mapping) do
         {
-          tag_with_name("8") => [tag_with_name("7"), tag_with_name("8")],
-          tag_with_name("6") => [tag_with_name("5"), tag_with_name("6")],
+          tag_with_name("8") => [tag_with_name("6"), tag_with_name("8")],
+          tag_with_name("6") => [tag_with_name("4"), tag_with_name("6")],
           tag_with_name("4") => [tag_with_name("3"), tag_with_name("4")],
-          tag_with_name("3") => [tag_with_name("2"), tag_with_name("3")],
+          tag_with_name("3") => [tag_with_name("1"), tag_with_name("3")],
           tag_with_name("1") => [nil, tag_with_name("1")]
         }
       end


### PR DESCRIPTION
If I am excluding tags, I do not expect them to be referenced in any way. Instead, they are still referenced in the diff links. This changes behavior to make this so. This may be considered a breaking change, but the current behavior doesn't make sense to me as it is -- I'd be happy to hear counterpoints.

This fixes https://github.com/github-changelog-generator/github-changelog-generator/issues/842.
