### PR TITLE
Revert "More concurrency"

### DIFF
--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency("activesupport")
-  spec.add_runtime_dependency("async", ">= 1.25.0")
   spec.add_runtime_dependency("async-http-faraday")
   spec.add_runtime_dependency("faraday-http-cache")
   spec.add_runtime_dependency("multi_json")

--- a/lib/github_changelog_generator/generator/generator.rb
+++ b/lib/github_changelog_generator/generator/generator.rb
@@ -49,21 +49,18 @@ module GitHubChangelogGenerator
     # @return [String] Generated changelog file
     def compound_changelog
       @options.load_custom_ruby_files
+      fetch_and_filter_tags
+      fetch_issues_and_pr
 
-      Sync do
-        fetch_and_filter_tags
-        fetch_issues_and_pr
-
-        log = if @options[:unreleased_only]
-                generate_entry_between_tags(@filtered_tags[0], nil)
-              else
-                generate_entries_for_all_tags
-              end
-        log += File.read(@options[:base]) if File.file?(@options[:base])
-        log = remove_old_fixed_string(log)
-        log = insert_fixed_string(log)
-        @log = log
-      end
+      log = if @options[:unreleased_only]
+              generate_entry_between_tags(@filtered_tags[0], nil)
+            else
+              generate_entries_for_all_tags
+            end
+      log += File.read(@options[:base]) if File.file?(@options[:base])
+      log = remove_old_fixed_string(log)
+      log = insert_fixed_string(log)
+      @log = log
     end
 
     private

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -227,6 +227,8 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
 
         # to clear line from prev print
         print_empty_line
+
+        client.agent.close
       end
 
       Helper.log.info "Fetching events for issues and PR: #{i}"
@@ -254,6 +256,8 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
         end
 
         barrier.wait
+
+        client.agent.close
       end
 
       nil
@@ -313,6 +317,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
           end
 
           barrier.wait
+          client.agent.close
 
           @commits.sort! do |b, a|
             a[:commit][:author][:date] <=> b[:commit][:author][:date]


### PR DESCRIPTION
Reverts github-changelog-generator/github-changelog-generator#921

With the async code in place, I get:
```
Traceback (most recent call last):
        1362: from /usr/local/bundle/gems/async-1.28.9/lib/async/task.rb:265:in `block in make_fiber'
        1361: from /usr/local/bundle/gems/github_changelog_generator-1.15.2/lib/github_changelog_generator/generator/generator.rb:55:in `block in compound_changelog'
        1360: from /usr/local/bundle/gems/github_changelog_generator-1.15.2/lib/github_changelog_generator/generator/generator.rb:152:in `fetch_issues_and_pr'
        1359: from /usr/local/bundle/gems/github_changelog_generator-1.15.2/lib/github_changelog_generator/generator/generator_fetcher.rb:48:in `add_first_occurring_tag_to_prs'
        1358: from /usr/local/bundle/gems/github_changelog_generator-1.15.2/lib/github_changelog_generator/generator/generator_fetcher.rb:65:in `associate_tagged_prs'
        1357: from /usr/local/bundle/gems/github_changelog_generator-1.15.2/lib/github_changelog_generator/octo_fetcher.rb:367:in `fetch_tag_shas'
        1356: from /usr/local/bundle/gems/github_changelog_generator-1.15.2/lib/github_changelog_generator/octo_fetcher.rb:367:in `each'
        1355: from /usr/local/bundle/gems/github_changelog_generator-1.15.2/lib/github_changelog_generator/octo_fetcher.rb:368:in `block in fetch_tag_shas'
         ... 1350 levels...
           4: from /usr/local/bundle/gems/github_changelog_generator-1.15.2/lib/github_changelog_generator/octo_fetcher.rb:353:in `commits_in_tag'
           3: from /usr/local/bundle/gems/github_changelog_generator-1.15.2/lib/github_changelog_generator/octo_fetcher.rb:353:in `each'
           2: from /usr/local/bundle/gems/github_changelog_generator-1.15.2/lib/github_changelog_generator/octo_fetcher.rb:354:in `block in commits_in_tag'
           1: from /usr/local/bundle/gems/sawyer-0.8.2/lib/sawyer/resource.rb:54:in `[]'
/usr/local/bundle/gems/sawyer-0.8.2/lib/sawyer/resource.rb:56:in `rescue in []': stack level too deep (SystemStackError)
```
But the generation works without it. I like the async, but it needs more testing.