### PR TITLE
Restoring tag hash references to string keys

### DIFF
--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -351,7 +351,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
     def fetch_tag_shas(tags)
       # Reverse the tags array to gain max benefit from the @commits_in_tag_cache
       tags.reverse_each do |tag|
-        tag["shas_in_tag"] = commits_in_tag(tag[:commit][:sha])
+        tag["shas_in_tag"] = commits_in_tag(tag["commit"]["sha"])
       end
     end
 

--- a/spec/unit/octo_fetcher_spec.rb
+++ b/spec/unit/octo_fetcher_spec.rb
@@ -104,9 +104,9 @@ describe GitHubChangelogGenerator::OctoFetcher do
       ]
     end
 
-    let(:tag0) { { name: "tag-0", commit: { sha: "0" } } }
-    let(:tag1) { { name: "tag-1", commit: { sha: "1" } } }
-    let(:tag6) { { name: "tag-6", commit: { sha: "6" } } }
+    let(:tag0) { { "name" => "tag-0", "commit" => { "sha" => "0" } } }
+    let(:tag1) { { "name" => "tag-1", "commit" => { "sha" => "1" } } }
+    let(:tag6) { { "name" => "tag-6", "commit" => { "sha" => "6" } } }
 
     before do
       allow(fetcher).to receive(:commits).and_return(commits)


### PR DESCRIPTION
Fixing issue that I created in [another pull request](https://github.com/github-changelog-generator/github-changelog-generator/pull/936#issuecomment-782025779).

I changed how the `tag` hash's keys were being references from strings to symbols. I made the change solely for testing purposes and the convenience of using symbols.