### PR TITLE
Rake Task: avoid calling super with arguments to avoid an ArgumentError

### DIFF
--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -31,7 +31,6 @@ module GitHubChangelogGenerator
     #
     #   GitHubChangelogGenerator::RakeTask.new
     def initialize(*args, &task_block)
-      super
       @name = args.shift || :changelog
 
       define(args, &task_block)

--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -30,7 +30,8 @@ module GitHubChangelogGenerator
     # Example
     #
     #   GitHubChangelogGenerator::RakeTask.new
-    def initialize(*args, &task_block) # rubocop:disable Lint/MissingSuper
+    def initialize(*args, &task_block)
+      super()
       @name = args.shift || :changelog
 
       define(args, &task_block)

--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -30,7 +30,7 @@ module GitHubChangelogGenerator
     # Example
     #
     #   GitHubChangelogGenerator::RakeTask.new
-    def initialize(*args, &task_block)
+    def initialize(*args, &task_block) # rubocop:disable Lint/MissingSuper
       @name = args.shift || :changelog
 
       define(args, &task_block)


### PR DESCRIPTION
Rake's RakeLib base class does not define a specific initializer. 

In the initializer for our RakeTask creation class, we call super sans args.

When we _do_ call it with a specific name, `super` fails like:

```
ArgumentError: wrong number of arguments (given 1, expected 0)
/home/travis/build/dev-sec/chef-os-hardening/vendor/bundle/ruby/2.6.0/gems/github_changelog_generator-1.16.0/lib/github_changelog_generator/task.rb:34:in `initialize'
/home/travis/build/dev-sec/chef-os-hardening/vendor/bundle/ruby/2.6.0/gems/github_changelog_generator-1.16.0/lib/github_changelog_generator/task.rb:34:in `initialize'
```

Fixes #942 