### PR TITLE
Update help output to reflect required args.

### DIFF
--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -43,55 +43,55 @@ module GitHubChangelogGenerator
         opts.on("-p", "--project PROJECT", "Name of project on GitHub.") do |last|
           options[:project] = last
         end
-        opts.on("-t", "--token [TOKEN]", "To make more than 50 requests per hour your GitHub token is required. You can generate it at: https://github.com/settings/tokens/new") do |last|
+        opts.on("-t", "--token TOKEN", "To make more than 50 requests per hour your GitHub token is required. You can generate it at: https://github.com/settings/tokens/new") do |last|
           options[:token] = last
         end
         opts.on("-f", "--date-format FORMAT", "Date format. Default is %Y-%m-%d.") do |last|
           options[:date_format] = last
         end
-        opts.on("-o", "--output [NAME]", "Output file. To print to STDOUT instead, use blank as path. Default is CHANGELOG.md") do |last|
+        opts.on("-o", "--output NAME", "Output file. To print to STDOUT instead, use blank as path. Default is CHANGELOG.md") do |last|
           options[:output] = last
         end
-        opts.on("-b", "--base [NAME]", "Optional base file to append generated changes to.") do |last|
+        opts.on("-b", "--base NAME", "Optional base file to append generated changes to. Default is HISTORY.md") do |last|
           options[:base] = last
         end
-        opts.on("--summary-label [LABEL]", "Set up custom label for the release summary section. Default is \"\".") do |v|
+        opts.on("--summary-label LABEL", "Set up custom label for the release summary section. Default is \"\".") do |v|
           options[:summary_prefix] = v
         end
-        opts.on("--breaking-label [LABEL]", "Set up custom label for the breaking changes section. Default is \"**Breaking changes:**\".") do |v|
+        opts.on("--breaking-label LABEL", "Set up custom label for the breaking changes section. Default is \"**Breaking changes:**\".") do |v|
           options[:breaking_prefix] = v
         end
-        opts.on("--enhancement-label [LABEL]", "Set up custom label for enhancements section. Default is \"**Implemented enhancements:**\".") do |v|
+        opts.on("--enhancement-label LABEL", "Set up custom label for enhancements section. Default is \"**Implemented enhancements:**\".") do |v|
           options[:enhancement_prefix] = v
         end
-        opts.on("--bugs-label [LABEL]", "Set up custom label for bug-fixes section. Default is \"**Fixed bugs:**\".") do |v|
+        opts.on("--bugs-label LABEL", "Set up custom label for bug-fixes section. Default is \"**Fixed bugs:**\".") do |v|
           options[:bug_prefix] = v
         end
-        opts.on("--deprecated-label [LABEL]", "Set up custom label for the deprecated changes section. Default is \"**Deprecated:**\".") do |v|
+        opts.on("--deprecated-label LABEL", "Set up custom label for the deprecated changes section. Default is \"**Deprecated:**\".") do |v|
           options[:deprecated_prefix] = v
         end
-        opts.on("--removed-label [LABEL]", "Set up custom label for the removed changes section. Default is \"**Removed:**\".") do |v|
+        opts.on("--removed-label LABEL", "Set up custom label for the removed changes section. Default is \"**Removed:**\".") do |v|
           options[:removed_prefix] = v
         end
-        opts.on("--security-label [LABEL]", "Set up custom label for the security changes section. Default is \"**Security fixes:**\".") do |v|
+        opts.on("--security-label LABEL", "Set up custom label for the security changes section. Default is \"**Security fixes:**\".") do |v|
           options[:security_prefix] = v
         end
-        opts.on("--issues-label [LABEL]", "Set up custom label for closed-issues section. Default is \"**Closed issues:**\".") do |v|
+        opts.on("--issues-label LABEL", "Set up custom label for closed-issues section. Default is \"**Closed issues:**\".") do |v|
           options[:issue_prefix] = v
         end
-        opts.on("--header-label [LABEL]", "Set up custom header label. Default is \"# Changelog\".") do |v|
+        opts.on("--header-label LABEL", "Set up custom header label. Default is \"# Changelog\".") do |v|
           options[:header] = v
         end
-        opts.on("--configure-sections [Hash, String]", "Define your own set of sections which overrides all default sections.") do |v|
+        opts.on("--configure-sections HASH, STRING", "Define your own set of sections which overrides all default sections.") do |v|
           options[:configure_sections] = v
         end
-        opts.on("--add-sections [Hash, String]", "Add new sections but keep the default sections.") do |v|
+        opts.on("--add-sections HASH, STRING", "Add new sections but keep the default sections.") do |v|
           options[:add_sections] = v
         end
-        opts.on("--front-matter [JSON]", "Add YAML front matter. Formatted as JSON because it's easier to add on the command line.") do |v|
+        opts.on("--front-matter JSON", "Add YAML front matter. Formatted as JSON because it's easier to add on the command line.") do |v|
           options[:frontmatter] = "#{JSON.parse(v).to_yaml}---\n"
         end
-        opts.on("--pr-label [LABEL]", "Set up custom label for pull requests section. Default is \"**Merged pull requests:**\".") do |v|
+        opts.on("--pr-label LABEL", "Set up custom label for pull requests section. Default is \"**Merged pull requests:**\".") do |v|
           options[:merge_prefix] = v
         end
         opts.on("--[no-]issues", "Include closed issues in changelog. Default is true.") do |v|
@@ -124,7 +124,7 @@ module GitHubChangelogGenerator
         opts.on("--[no-]unreleased", "Add to log unreleased closed issues. Default is true.") do |v|
           options[:unreleased] = v
         end
-        opts.on("--unreleased-label [label]", "Set up custom label for unreleased closed issues section. Default is \"**Unreleased:**\".") do |v|
+        opts.on("--unreleased-label LABEL", "Set up custom label for unreleased closed issues section. Default is \"**Unreleased:**\".") do |v|
           options[:unreleased_label] = v
         end
         opts.on("--[no-]compare-link", "Include compare link (Full Changelog) between older version and newer version. Default is true.") do |v|
@@ -160,13 +160,13 @@ module GitHubChangelogGenerator
         opts.on("--issue-line-labels x,y,z", Array, 'The specified labels will be shown in brackets next to each matching issue. Use "ALL" to show all labels. Default is [].') do |list|
           options[:issue_line_labels] = list
         end
-        opts.on("--include-tags-regex [REGEX]", "Apply a regular expression on tag names so that they can be included, for example: --include-tags-regex \".*\+\d{1,}\".") do |last|
+        opts.on("--include-tags-regex REGEX", "Apply a regular expression on tag names so that they can be included, for example: --include-tags-regex \".*\+\d{1,}\".") do |last|
           options[:include_tags_regex] = last
         end
         opts.on("--exclude-tags  x,y,z", Array, "Changelog will exclude specified tags") do |list|
           options[:exclude_tags] = list
         end
-        opts.on("--exclude-tags-regex [REGEX]", "Apply a regular expression on tag names so that they can be excluded, for example: --exclude-tags-regex \".*\+\d{1,}\".") do |last|
+        opts.on("--exclude-tags-regex REGEX", "Apply a regular expression on tag names so that they can be excluded, for example: --exclude-tags-regex \".*\+\d{1,}\".") do |last|
           options[:exclude_tags_regex] = last
         end
         opts.on("--since-tag  x", "Changelog will start after specified tag.") do |v|
@@ -178,37 +178,37 @@ module GitHubChangelogGenerator
         opts.on("--since-commit  x", "Fetch only commits after this time. eg. \"2017-01-01 10:00:00\"") do |v|
           options[:since_commit] = v
         end
-        opts.on("--max-issues [NUMBER]", Integer, "Maximum number of issues to fetch from GitHub. Default is unlimited.") do |max|
+        opts.on("--max-issues NUMBER", Integer, "Maximum number of issues to fetch from GitHub. Default is unlimited.") do |max|
           options[:max_issues] = max
         end
-        opts.on("--release-url [URL]", "The URL to point to for release links, in printf format (with the tag as variable).") do |url|
+        opts.on("--release-url URL", "The URL to point to for release links, in printf format (with the tag as variable).") do |url|
           options[:release_url] = url
         end
-        opts.on("--github-site [URL]", "The Enterprise GitHub site where your project is hosted.") do |last|
+        opts.on("--github-site URL", "The Enterprise GitHub site where your project is hosted.") do |last|
           options[:github_site] = last
         end
-        opts.on("--github-api [URL]", "The enterprise endpoint to use for your GitHub API.") do |last|
+        opts.on("--github-api URL", "The enterprise endpoint to use for your GitHub API.") do |last|
           options[:github_endpoint] = last
         end
         opts.on("--simple-list", "Create a simple list from issues and pull requests. Default is false.") do |v|
           options[:simple_list] = v
         end
-        opts.on("--future-release [RELEASE-VERSION]", "Put the unreleased changes in the specified release number.") do |future_release|
+        opts.on("--future-release RELEASE-VERSION", "Put the unreleased changes in the specified release number.") do |future_release|
           options[:future_release] = future_release
         end
-        opts.on("--release-branch [RELEASE-BRANCH]", "Limit pull requests to the release branch, such as master or release.") do |release_branch|
+        opts.on("--release-branch RELEASE-BRANCH", "Limit pull requests to the release branch, such as master or release.") do |release_branch|
           options[:release_branch] = release_branch
         end
         opts.on("--[no-]http-cache", "Use HTTP Cache to cache GitHub API requests (useful for large repos). Default is true.") do |http_cache|
           options[:http_cache] = http_cache
         end
-        opts.on("--cache-file [CACHE-FILE]", "Filename to use for cache. Default is github-changelog-http-cache in a temporary directory.") do |cache_file|
+        opts.on("--cache-file CACHE-FILE", "Filename to use for cache. Default is github-changelog-http-cache in a temporary directory.") do |cache_file|
           options[:cache_file] = cache_file
         end
-        opts.on("--cache-log [CACHE-LOG]", "Filename to use for cache log. Default is github-changelog-logger.log in a temporary directory.") do |cache_log|
+        opts.on("--cache-log CACHE-LOG", "Filename to use for cache log. Default is github-changelog-logger.log in a temporary directory.") do |cache_log|
           options[:cache_log] = cache_log
         end
-        opts.on("--ssl-ca-file [PATH]", "Path to cacert.pem file. Default is a bundled lib/github_changelog_generator/ssl_certs/cacert.pem. Respects SSL_CA_PATH.") do |ssl_ca_file|
+        opts.on("--ssl-ca-file PATH", "Path to cacert.pem file. Default is a bundled lib/github_changelog_generator/ssl_certs/cacert.pem. Respects SSL_CA_PATH.") do |ssl_ca_file|
           options[:ssl_ca_file] = ssl_ca_file
         end
         opts.on("--require x,y,z", Array, "Path to Ruby file(s) to require before generating changelog.") do |paths|

--- a/man/git-generate-changelog.1
+++ b/man/git-generate-changelog.1
@@ -13,115 +13,115 @@
 Automatically generate changelog from your tags, issues, labels and pull requests on GitHub\.
 .
 .SH "OPTIONS"
-\-u, \-\-user [USER]
+\-u, \-\-user USER
 .
 .P
 Username of the owner of target GitHub repo\.
 .
 .P
-\-p, \-\-project [PROJECT]
+\-p, \-\-project PROJECT
 .
 .P
 Name of project on GitHub\.
 .
 .P
-\-t, \-\-token [TOKEN]
+\-t, \-\-token TOKEN
 .
 .P
 To make more than 50 requests per hour your GitHub token is required\. You can generate it at: https://github\.com/settings/tokens/new
 .
 .P
-\-f, \-\-date\-format [FORMAT]
+\-f, \-\-date\-format FORMAT
 .
 .P
 Date format\. Default is %Y\-%m\-%d\.
 .
 .P
-\-o, \-\-output [NAME]
+\-o, \-\-output NAME
 .
 .P
 Output file\. To print to STDOUT instead, use blank as path\. Default is CHANGELOG\.md\.
 .
 .P
-\-b, \-\-base [NAME]
+\-b, \-\-base NAME
 .
 .P
-Optional base file to append generated changes to\.
+Optional base file to append generated changes to\. Default is HISTORY\.md\.
 .
 .P
-\-\-summary\-label [LABEL]
+\-\-summary\-label LABEL
 .
 .P
 Set up custom label for the release summary section\. Default is ""\.
 .
 .P
-\-\-breaking\-label [LABEL]
+\-\-breaking\-label LABEL
 .
 .P
 Set up custom label for breaking changes section\. Default is "\fBBreaking changes:\fR"\.
 .
 .P
-\-\-enhancement\-label [LABEL]
+\-\-enhancement\-label LABEL
 .
 .P
 Set up custom label for enhancements section\. Default is "\fBImplemented enhancements:\fR"\.
 .
 .P
-\-\-bugs\-label [LABEL]
+\-\-bugs\-label LABEL
 .
 .P
 Set up custom label for bug\-fixes section\. Default is "\fBFixed bugs:\fR"\.
 .
 .P
-\-\-deprecated\-label [LABEL]
+\-\-deprecated\-label LABEL
 .
 .P
 Set up custom label for deprecated section\. Default is "\fBDeprecated:\fR"\.
 .
 .P
-\-\-removed\-label [LABEL]
+\-\-removed\-label LABEL
 .
 .P
 Set up custom label for removed section\. Default is "\fBRemoved:\fR"\.
 .
 .P
-\-\-security\-label [LABEL]
+\-\-security\-label LABEL
 .
 .P
 Set up custom label for security section\. Default is "\fBSecurity:\fR"\.
 .
 .P
-\-\-issues\-label [LABEL]
+\-\-issues\-label LABEL
 .
 .P
 Set up custom label for closed\-issues section\. Default is "\fBClosed issues:\fR"\.
 .
 .P
-\-\-header\-label [LABEL]
+\-\-header\-label LABEL
 .
 .P
 Set up custom header label\. Default is "# Changelog"\.
 .
 .P
-\-\-configure\-sections [HASH, STRING]
+\-\-configure\-sections HASH, STRING
 .
 .P
 Define your own set of sections which overrides all default sections\.
 .
 .P
-\-\-add\-sections [HASH, STRING]
+\-\-add\-sections HASH, STRING
 .
 .P
 Add new sections but keep the default sections\.
 .
 .P
-\-\-front\-matter [JSON]
+\-\-front\-matter JSON
 .
 .P
 Add YAML front matter\. Formatted as JSON because it\'s easier to add on the command line\.
 .
 .P
-\-\-pr\-label [LABEL]
+\-\-pr\-label LABEL
 .
 .P
 Set up custom label for pull requests section\. Default is "\fBMerged pull requests:\fR"\.
@@ -187,7 +187,7 @@ Generate log from unreleased closed issues only\.
 Add to log unreleased closed issues\. Default is true\.
 .
 .P
-\-\-unreleased\-label [label]
+\-\-unreleased\-label LABEL
 .
 .P
 Set up custom label for unreleased closed issues section\. Default is "\fBUnreleased:\fR"\.
@@ -265,7 +265,7 @@ The specified labels will be shown in brackets next to each matching issue\. Use
 Changelog will exclude specified tags\.
 .
 .P
-\-\-exclude\-tags\-regex [REGEX]
+\-\-exclude\-tags\-regex REGEX
 .
 .P
 Apply a regular expression on tag names so that they can be excluded, for example: \-\-exclude\-tags\-regex "\.*+\ed{1,}"\.
@@ -289,25 +289,25 @@ Changelog will end before specified tag\.
 Fetch only commits after this time\. eg\. "2017\-01\-01 10:00:00"
 .
 .P
-\-\-max\-issues [NUMBER]
+\-\-max\-issues NUMBER
 .
 .P
 Maximum number of issues to fetch from GitHub\. Default is unlimited\.
 .
 .P
-\-\-release\-url [URL]
+\-\-release\-url URL
 .
 .P
 The URL to point to for release links, in printf format (with the tag as variable)\.
 .
 .P
-\-\-github\-site [URL]
+\-\-github\-site URL
 .
 .P
 The Enterprise GitHub site where your project is hosted\.
 .
 .P
-\-\-github\-api [URL]
+\-\-github\-api URL
 .
 .P
 The enterprise endpoint to use for your GitHub API\.
@@ -319,13 +319,13 @@ The enterprise endpoint to use for your GitHub API\.
 Create a simple list from issues and pull requests\. Default is false\.
 .
 .P
-\-\-future\-release [RELEASE\-VERSION]
+\-\-future\-release RELEASE\-VERSION
 .
 .P
 Put the unreleased changes in the specified release number\.
 .
 .P
-\-\-release\-branch [RELEASE\-BRANCH]
+\-\-release\-branch RELEASE\-BRANCH
 .
 .P
 Limit pull requests to the release branch, such as master or release\.
@@ -337,19 +337,19 @@ Limit pull requests to the release branch, such as master or release\.
 Use HTTP Cache to cache GitHub API requests (useful for large repos)\. Default is true\.
 .
 .P
-\-\-[no\-]cache\-file [CACHE\-FILE]
+\-\-[no\-]cache\-file CACHE\-FILE
 .
 .P
 Filename to use for cache\. Default is github\-changelog\-http\-cache in a temporary directory\.
 .
 .P
-\-\-cache\-log [CACHE\-LOG]
+\-\-cache\-log CACHE\-LOG
 .
 .P
 Filename to use for cache log\. Default is github\-changelog\-logger\.log in a temporary directory\.
 .
 .P
-\-\-ssl\-ca\-file [PATH]
+\-\-ssl\-ca\-file PATH
 .
 .P
 Path to cacert\.pem file\. Default is a bundled lib/github_changelog_generator/ssl_certs/cacert\.pem\. Respects SSL_CA_PATH\.

--- a/man/git-generate-changelog.1.html
+++ b/man/git-generate-changelog.1.html
@@ -85,79 +85,79 @@
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
-<p>  -u, --user [USER]</p>
+<p>  -u, --user USER</p>
 
 <p>  Username of the owner of target GitHub repo.</p>
 
-<p>  -p, --project [PROJECT]</p>
+<p>  -p, --project PROJECT</p>
 
 <p>  Name of project on GitHub.</p>
 
-<p>  -t, --token [TOKEN]</p>
+<p>  -t, --token TOKEN</p>
 
 <p>  To make more than 50 requests per hour your GitHub token is required. You can generate it at: https://github.com/settings/tokens/new</p>
 
-<p>  -f, --date-format [FORMAT]</p>
+<p>  -f, --date-format FORMAT</p>
 
 <p>  Date format. Default is %Y-%m-%d.</p>
 
-<p>  -o, --output [NAME]</p>
+<p>  -o, --output NAME</p>
 
 <p>  Output file. To print to STDOUT instead, use blank as path. Default is CHANGELOG.md.</p>
 
-<p>  -b, --base [NAME]</p>
+<p>  -b, --base NAME</p>
 
 <p>  Optional base file to append generated changes to.</p>
 
-<p>  --summary-label [LABEL]</p>
+<p>  --summary-label LABEL</p>
 
 <p>  Set up custom label for the release summary section. Default is "".</p>
 
-<p>  --breaking-label [LABEL]</p>
+<p>  --breaking-label LABEL</p>
 
 <p>  Set up custom label for breaking changes section. Default is "<strong>Breaking changes:</strong>".</p>
 
-<p>  --enhancement-label [LABEL]</p>
+<p>  --enhancement-label LABEL</p>
 
 <p>  Set up custom label for enhancements section. Default is "<strong>Implemented enhancements:</strong>".</p>
 
-<p>  --bugs-label [LABEL]</p>
+<p>  --bugs-label LABEL</p>
 
 <p>  Set up custom label for bug-fixes section. Default is "<strong>Fixed bugs:</strong>".</p>
 
-<p>  --deprecated-label [LABEL]</p>
+<p>  --deprecated-label LABEL</p>
 
 <p>  Set up custom label for deprecated section. Default is "<strong>Deprecated:</strong>".</p>
 
-<p>  --removed-label [LABEL]</p>
+<p>  --removed-label LABEL</p>
 
 <p>  Set up custom label for removed section. Default is "<strong>Removed:</strong>".</p>
 
-<p>  --security-label [LABEL]</p>
+<p>  --security-label LABEL</p>
 
 <p>  Set up custom label for security section. Default is "<strong>Security:</strong>".</p>
 
-<p>  --issues-label [LABEL]</p>
+<p>  --issues-label LABEL</p>
 
 <p>  Set up custom label for closed-issues section. Default is "<strong>Closed issues:</strong>".</p>
 
-<p>  --header-label [LABEL]</p>
+<p>  --header-label LABEL</p>
 
 <p>  Set up custom header label. Default is "# Changelog".</p>
 
-<p>  --configure-sections [HASH, STRING]</p>
+<p>  --configure-sections HASH, STRING</p>
 
 <p>  Define your own set of sections which overrides all default sections.</p>
 
-<p>  --add-sections [HASH, STRING]</p>
+<p>  --add-sections HASH, STRING</p>
 
 <p>  Add new sections but keep the default sections.</p>
 
-<p>  --front-matter [JSON]</p>
+<p>  --front-matter JSON</p>
 
 <p>  Add YAML front matter. Formatted as JSON because it's easier to add on the command line.</p>
 
-<p>  --pr-label [LABEL]</p>
+<p>  --pr-label LABEL</p>
 
 <p>  Set up custom label for pull requests section. Default is "<strong>Merged pull requests:</strong>".</p>
 
@@ -201,7 +201,7 @@
 
 <p>  Add to log unreleased closed issues. Default is true.</p>
 
-<p>  --unreleased-label [label]</p>
+<p>  --unreleased-label LABEL</p>
 
 <p>  Set up custom label for unreleased closed issues section. Default is "<strong>Unreleased:</strong>".</p>
 
@@ -253,7 +253,7 @@
 
 <p>  Changelog will exclude specified tags.</p>
 
-<p>  --exclude-tags-regex [REGEX]</p>
+<p>  --exclude-tags-regex REGEX</p>
 
 <p>  Apply a regular expression on tag names so that they can be excluded, for example: --exclude-tags-regex ".*+\d{1,}".</p>
 
@@ -269,19 +269,19 @@
 
 <p>  Fetch only commits after this time. eg. "2017-01-01 10:00:00"</p>
 
-<p>  --max-issues [NUMBER]</p>
+<p>  --max-issues NUMBER</p>
 
 <p>  Maximum number of issues to fetch from GitHub. Default is unlimited.</p>
 
-<p>  --release-url [URL]</p>
+<p>  --release-url URL</p>
 
 <p>  The URL to point to for release links, in printf format (with the tag as variable).</p>
 
-<p>  --github-site [URL]</p>
+<p>  --github-site URL</p>
 
 <p>  The Enterprise GitHub site where your project is hosted.</p>
 
-<p>  --github-api [URL]</p>
+<p>  --github-api URL</p>
 
 <p>  The enterprise endpoint to use for your GitHub API.</p>
 
@@ -289,11 +289,11 @@
 
 <p>  Create a simple list from issues and pull requests. Default is false.</p>
 
-<p>  --future-release [RELEASE-VERSION]</p>
+<p>  --future-release RELEASE-VERSION</p>
 
 <p>  Put the unreleased changes in the specified release number.</p>
 
-<p>  --release-branch [RELEASE-BRANCH]</p>
+<p>  --release-branch RELEASE-BRANCH</p>
 
 <p>  Limit pull requests to the release branch, such as master or release.</p>
 
@@ -301,15 +301,15 @@
 
 <p>  Use HTTP Cache to cache GitHub API requests (useful for large repos). Default is true.</p>
 
-<p>  --[no-]cache-file [CACHE-FILE]</p>
+<p>  --[no-]cache-file CACHE-FILE</p>
 
 <p>  Filename to use for cache. Default is github-changelog-http-cache in a temporary directory.</p>
 
-<p>  --cache-log [CACHE-LOG]</p>
+<p>  --cache-log CACHE-LOG</p>
 
 <p>  Filename to use for cache log. Default is github-changelog-logger.log in a temporary directory.</p>
 
-<p>  --ssl-ca-file [PATH]</p>
+<p>  --ssl-ca-file PATH</p>
 
 <p>  Path to cacert.pem file. Default is a bundled lib/github_changelog_generator/ssl_certs/cacert.pem. Respects SSL_CA_PATH.</p>
 

--- a/man/git-generate-changelog.html
+++ b/man/git-generate-changelog.html
@@ -84,47 +84,47 @@
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
-<p>  -u, --user [USER]</p>
+<p>  -u, --user USER</p>
 
 <p>  Username of the owner of target GitHub repo</p>
 
-<p>  -p, --project [PROJECT]</p>
+<p>  -p, --project PROJECT</p>
 
 <p>  Name of project on GitHub</p>
 
-<p>  -t, --token [TOKEN]</p>
+<p>  -t, --token TOKEN</p>
 
 <p>  To make more than 50 requests per hour your GitHub token is required. You can generate it at: https://github.com/settings/tokens/new</p>
 
-<p>  -f, --date-format [FORMAT]</p>
+<p>  -f, --date-format FORMAT</p>
 
 <p>  Date format. Default is %Y-%m-%d</p>
 
-<p>  -o, --output [NAME]</p>
+<p>  -o, --output NAME</p>
 
 <p>  Output file. Default is CHANGELOG.md</p>
 
-<p>  -b, --base [NAME]</p>
+<p>  -b, --base NAME</p>
 
 <p>  Optional base file to append generated changes to.</p>
 
-<p>   --bugs-label [LABEL]</p>
+<p>   --bugs-label LABEL</p>
 
 <p>   Setup custom label for bug-fixes section. Default is "<strong>Fixed bugs:</strong></p>
 
-<p>   --enhancement-label [LABEL]</p>
+<p>   --enhancement-label LABEL</p>
 
 <p>   Setup custom label for enhancements section. Default is "<strong>Implemented enhancements:</strong>"</p>
 
-<p>   --issues-label [LABEL]</p>
+<p>   --issues-label LABEL</p>
 
 <p>   Setup custom label for closed-issues section. Default is "<strong>Closed issues:</strong>"</p>
 
-<p>   --header-label [LABEL]</p>
+<p>   --header-label LABEL</p>
 
 <p>   Setup custom header label. Default is "# Changelog"</p>
 
-<p>   --pr-label [LABEL]</p>
+<p>   --pr-label LABEL</p>
 
 <p>   Setup custom label for pull requests section. Default is "<strong>Merged pull requests:</strong>"</p>
 
@@ -160,7 +160,7 @@
 
 <p>   Add to log unreleased closed issues. Default is true</p>
 
-<p>   --unreleased-label [label]</p>
+<p>   --unreleased-label LABEL</p>
 
 <p>   Add to log unreleased closed issues. Default is true</p>
 
@@ -196,19 +196,19 @@
 
 <p>   Changelog will end before specified tag</p>
 
-<p>   --max-issues [NUMBER]</p>
+<p>   --max-issues NUMBER</p>
 
 <p>   Max number of issues to fetch from GitHub. Default is unlimited</p>
 
-<p>   --release-url [URL]</p>
+<p>   --release-url URL</p>
 
 <p>   The URL to point to for release links, in printf format (with the tag as variable).</p>
 
-<p>   --github-site [URL]</p>
+<p>   --github-site URL</p>
 
 <p>   The Enterprise Github site on which your project is hosted.</p>
 
-<p>   --github-api [URL]</p>
+<p>   --github-api URL</p>
 
 <p>   The enterprise endpoint to use for your Github API.</p>
 
@@ -216,15 +216,15 @@
 
 <p>   Create simple list from issues and pull requests. Default is false.</p>
 
-<p>   --future-release [RELEASE-VERSION]</p>
+<p>   --future-release RELEASE-VERSION</p>
 
 <p>   Put the unreleased changes in the specified release number.</p>
 
-<p>   --configure-sections [HASH, STRING]</p>
+<p>   --configure-sections HASH, STRING</p>
 
 <p>   Define your own set of sections which overrides all default sections") do |v|</p>
 
-<p>   --add-sections [HASH, STRING]</p>
+<p>   --add-sections HASH, STRING</p>
 
 <p>   Add new sections but keep the default sections"</p>
 

--- a/man/git-generate-changelog.md
+++ b/man/git-generate-changelog.md
@@ -11,79 +11,79 @@ Automatically generate changelog from your tags, issues, labels and pull request
 
 ## OPTIONS
 
-  -u, --user [USER]
+  -u, --user USER
 
   Username of the owner of target GitHub repo.
 
-  -p, --project [PROJECT]
+  -p, --project PROJECT
 
   Name of project on GitHub.
 
-  -t, --token [TOKEN]
+  -t, --token TOKEN
 
   To make more than 50 requests per hour your GitHub token is required. You can generate it at: https://github.com/settings/tokens/new
 
-  -f, --date-format [FORMAT]
+  -f, --date-format FORMAT
 
   Date format. Default is %Y-%m-%d.
 
-  -o, --output [NAME]
+  -o, --output NAME
 
   Output file. To print to STDOUT instead, use blank as path. Default is CHANGELOG.md.
 
-  -b, --base [NAME]
+  -b, --base NAME
 
-  Optional base file to append generated changes to.
+  Optional base file to append generated changes to. Default is HISTORY.md.
 
-  --summary-label [LABEL]
+  --summary-label LABEL
 
   Set up custom label for the release summary section. Default is "".
 
-  --breaking-label [LABEL]
+  --breaking-label LABEL
 
   Set up custom label for breaking changes section. Default is "**Breaking changes:**".
 
-  --enhancement-label [LABEL]
+  --enhancement-label LABEL
 
   Set up custom label for enhancements section. Default is "**Implemented enhancements:**".
 
-  --bugs-label [LABEL]
+  --bugs-label LABEL
 
   Set up custom label for bug-fixes section. Default is "**Fixed bugs:**".
 
-  --deprecated-label [LABEL]
+  --deprecated-label LABEL
 
   Set up custom label for deprecated section. Default is "**Deprecated:**".
 
-  --removed-label [LABEL]
+  --removed-label LABEL
 
   Set up custom label for removed section. Default is "**Removed:**".
 
-  --security-label [LABEL]
+  --security-label LABEL
 
   Set up custom label for security section. Default is "**Security:**".
 
-  --issues-label [LABEL]
+  --issues-label LABEL
 
   Set up custom label for closed-issues section. Default is "**Closed issues:**".
 
-  --header-label [LABEL]
+  --header-label LABEL
 
   Set up custom header label. Default is "# Changelog".
 
-  --configure-sections [HASH, STRING]
+  --configure-sections HASH, STRING
 
   Define your own set of sections which overrides all default sections.
 
-  --add-sections [HASH, STRING]
+  --add-sections HASH, STRING
 
   Add new sections but keep the default sections.
 
-  --front-matter [JSON]
+  --front-matter JSON
 
   Add YAML front matter. Formatted as JSON because it's easier to add on the command line.
 
-  --pr-label [LABEL]
+  --pr-label LABEL
 
   Set up custom label for pull requests section. Default is "**Merged pull requests:**".
 
@@ -127,7 +127,7 @@ Automatically generate changelog from your tags, issues, labels and pull request
 
   Add to log unreleased closed issues. Default is true.
 
-  --unreleased-label [label]
+  --unreleased-label LABEL
 
   Set up custom label for unreleased closed issues section. Default is "**Unreleased:**".
 
@@ -179,7 +179,7 @@ Automatically generate changelog from your tags, issues, labels and pull request
 
   Changelog will exclude specified tags.
 
-  --exclude-tags-regex [REGEX]
+  --exclude-tags-regex REGEX
 
   Apply a regular expression on tag names so that they can be excluded, for example: --exclude-tags-regex ".*\+\d{1,}".
 
@@ -195,19 +195,19 @@ Automatically generate changelog from your tags, issues, labels and pull request
   
   Fetch only commits after this time. eg. "2017-01-01 10:00:00"
 
-  --max-issues [NUMBER]
+  --max-issues NUMBER
 
   Maximum number of issues to fetch from GitHub. Default is unlimited.
 
-  --release-url [URL]
+  --release-url URL
 
   The URL to point to for release links, in printf format (with the tag as variable).
 
-  --github-site [URL]
+  --github-site URL
 
   The Enterprise GitHub site where your project is hosted.
 
-  --github-api [URL]
+  --github-api URL
 
   The enterprise endpoint to use for your GitHub API.
 
@@ -215,11 +215,11 @@ Automatically generate changelog from your tags, issues, labels and pull request
 
   Create a simple list from issues and pull requests. Default is false.
 
-  --future-release [RELEASE-VERSION]
+  --future-release RELEASE-VERSION
 
   Put the unreleased changes in the specified release number.
 
-  --release-branch [RELEASE-BRANCH]
+  --release-branch RELEASE-BRANCH
 
   Limit pull requests to the release branch, such as master or release.
 
@@ -227,15 +227,15 @@ Automatically generate changelog from your tags, issues, labels and pull request
 
   Use HTTP Cache to cache GitHub API requests (useful for large repos). Default is true.
 
-  --[no-]cache-file [CACHE-FILE]
+  --[no-]cache-file CACHE-FILE
 
   Filename to use for cache. Default is github-changelog-http-cache in a temporary directory.
 
-  --cache-log [CACHE-LOG]
+  --cache-log CACHE-LOG
 
   Filename to use for cache log. Default is github-changelog-logger.log in a temporary directory.
 
-  --ssl-ca-file [PATH]
+  --ssl-ca-file PATH
 
   Path to cacert.pem file. Default is a bundled lib/github_changelog_generator/ssl_certs/cacert.pem. Respects SSL_CA_PATH.
 


### PR DESCRIPTION
This PR fixes #945

Help output messages should now properly reflect whether args are required.
I didn't find any Options which seemed to take optional arguments; they all look like they require args OR require zero args.

Another pair of eyes would be great to double-check!