### PR TITLE
Replace "require" with "require_relative" where possible

### DIFF
--- a/lib/github_changelog_generator.rb
+++ b/lib/github_changelog_generator.rb
@@ -10,13 +10,13 @@ require "json"
 require "multi_json"
 require "benchmark"
 
-require "github_changelog_generator/helper"
-require "github_changelog_generator/options"
-require "github_changelog_generator/parser"
-require "github_changelog_generator/parser_file"
-require "github_changelog_generator/generator/generator"
-require "github_changelog_generator/version"
-require "github_changelog_generator/reader"
+require_relative "github_changelog_generator/helper"
+require_relative "github_changelog_generator/options"
+require_relative "github_changelog_generator/parser"
+require_relative "github_changelog_generator/parser_file"
+require_relative "github_changelog_generator/generator/generator"
+require_relative "github_changelog_generator/version"
+require_relative "github_changelog_generator/reader"
 
 # The main module, where placed all classes (now, at least)
 module GitHubChangelogGenerator

--- a/lib/github_changelog_generator/generator/entry.rb
+++ b/lib/github_changelog_generator/generator/entry.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "github_changelog_generator/generator/section"
+require_relative "section"
 
 module GitHubChangelogGenerator
   # This class generates the content for a single changelog entry. An entry is

--- a/lib/github_changelog_generator/generator/generator.rb
+++ b/lib/github_changelog_generator/generator/generator.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require "github_changelog_generator/octo_fetcher"
-require "github_changelog_generator/generator/generator_fetcher"
-require "github_changelog_generator/generator/generator_processor"
-require "github_changelog_generator/generator/generator_tags"
-require "github_changelog_generator/generator/entry"
-require "github_changelog_generator/generator/section"
+require_relative "../octo_fetcher"
+require_relative "generator_fetcher"
+require_relative "generator_processor"
+require_relative "generator_tags"
+require_relative "entry"
+require_relative "section"
 
 module GitHubChangelogGenerator
   # Default error for ChangelogGenerator

--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "delegate"
-require "github_changelog_generator/helper"
+require_relative "helper"
 
 module GitHubChangelogGenerator
   # This class wraps Options, and knows a list of known options. Others options

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 require "optparse"
-require "github_changelog_generator/version"
-require "github_changelog_generator/helper"
+require_relative "version"
+require_relative "helper"
 
 module GitHubChangelogGenerator
   class Parser


### PR DESCRIPTION
Allows `bin/github_changelog_generator` to be invoked from anywhere.
This facilitates easier ad hoc testing locally.

This commit leaves specs unchanged on purpose.

See: https://github.com/rubocop/rubocop/issues/8748