### PR TITLE
Ruby 3 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,14 @@
 #
 version: 2.1
 orbs:
-  ruby: circleci/ruby@0.2.2
+  ruby: circleci/ruby@1.0
 
 shared_steps: &shared_steps
   steps:
     - run: ruby -v
     - checkout
     - ruby/load-cache
-    - run: gem install bundler:2.1.4
+    - run: gem install bundler:2.2.15
     - ruby/install-deps
     - ruby/save-cache
     - ruby/run-tests
@@ -59,6 +59,6 @@ workflows:
       - test:
           matrix:
             parameters:
-              tag: ["2.5", "2.6", "2.7"]
+              tag: ["2.5", "2.6", "2.7", "3.0"]
           requires:
             - lint

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -159,9 +159,9 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
       print "Fetching closed issues...\r" if @options[:verbose]
       issues = []
       page_i = 0
-      count_pages = calculate_pages(client, "issues", closed_pr_options)
+      count_pages = calculate_pages(client, "issues", **closed_pr_options)
 
-      iterate_pages(client, "issues", closed_pr_options) do |new_issues|
+      iterate_pages(client, "issues", **closed_pr_options) do |new_issues|
         page_i += PER_PAGE_NUMBER
         print_in_same_line("Fetching issues... #{page_i}/#{count_pages * PER_PAGE_NUMBER}")
         issues.concat(new_issues)
@@ -185,7 +185,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
       page_i = 0
       count_pages = calculate_pages(client, "pull_requests", options)
 
-      iterate_pages(client, "pull_requests", options) do |new_pr|
+      iterate_pages(client, "pull_requests", **options) do |new_pr|
         page_i += PER_PAGE_NUMBER
         log_string = "Fetching merged dates... #{page_i}/#{count_pages * PER_PAGE_NUMBER}"
         print_in_same_line(log_string)
@@ -215,7 +215,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
         issues.each do |issue|
           semaphore.async do
             issue["events"] = []
-            iterate_pages(client, "issue_events", issue["number"], preview) do |new_event|
+            iterate_pages(client, "issue_events", issue["number"], **preview) do |new_event|
               issue["events"].concat(new_event)
             end
             issue["events"] = issue["events"].map { |event| stringify_keys_deep(event.to_hash) }


### PR DESCRIPTION
It was incompatible with Ruby 3 because of https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Fixes #952
Fixes #928 