### PR TITLE
Use the githubchangeloggenerator Docker Hub org

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Using [Docker](https://www.docker.com/products/docker-desktop) is an alternative
 
 Example invocation:
 
-    $ docker run -it --rm -v "$(pwd)":/usr/local/src/your-app ferrarimarco/github-changelog-generator
+    $ docker run -it --rm -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator
 
 
 


### PR DESCRIPTION
I completed the migration from the `ferrarimarco` to  the `githubchangeloggenerator` Docker Hub org, and fixed automation to build and tag new images after a new gch release.

See: https://github.com/github-changelog-generator/docker-github-changelog-generator