### PR TITLE
Fix: always return an Array from #commits_in_branch

### DIFF
--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -104,7 +104,7 @@ module GitHubChangelogGenerator
         i = total - prs_left.count
         prs_left.reject do |pr|
           found = false
-          if pr["events"] && (event = pr["events"].find { |e| e["event"] == "merged" }) && sha_in_release_branch(event["commit_id"])
+          if pr["events"] && (event = pr["events"].find { |e| e["event"] == "merged" }) && sha_in_release_branch?(event["commit_id"])
             found = true
             i += 1
             print("Associating PRs with tags: #{i}/#{total}\r") if @options[:verbose]
@@ -137,7 +137,7 @@ module GitHubChangelogGenerator
             pr["first_occurring_tag"] = oldest_tag["name"]
             found = true
             i += 1
-          elsif sha_in_release_branch(rebased_sha)
+          elsif sha_in_release_branch?(rebased_sha)
             found = true
             i += 1
           else
@@ -195,10 +195,9 @@ module GitHubChangelogGenerator
     #
     # @param [String] sha SHA to check.
     # @return [Boolean] True if SHA is in the branch git history.
-    def sha_in_release_branch(sha)
+    def sha_in_release_branch?(sha)
       branch = @options[:release_branch] || @fetcher.default_branch
-      shas_in_branch = @fetcher.commits_in_branch(branch)
-      shas_in_branch.include?(sha)
+      @fetcher.commits_in_branch(branch).include?(sha)
     end
   end
 end

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -338,12 +338,15 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
       @default_branch ||= client.repository(user_project)[:default_branch]
     end
 
-    # @param [Object] name
+    # @param [String] name
+    # @return [Array<String>]
     def commits_in_branch(name)
       @branches ||= client.branches(user_project).map { |branch| [branch[:name], branch] }.to_h
 
       if (branch = @branches[name])
         commits_in_tag(branch[:commit][:sha])
+      else
+        []
       end
     end
 
@@ -351,7 +354,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
     # "shas_in_tag"
     #
     # @param [Array] tags The array of tags.
-    # @return [Nil] No return; tags are updated in-place.
+    # @return void
     def fetch_tag_shas(tags)
       # Reverse the tags array to gain max benefit from the @commits_in_tag_cache
       tags.reverse_each do |tag|


### PR DESCRIPTION
The problem was that a method which would return a list _could_ return `nil` instead of the empty list. This PR changes that to always return a list.

This commit also refactors the name of a method to reflect that it is a
predicate method.

Also: a YARD annotation, using the built-in 'void' type.

Fixes #954