### PR TITLE
README, gemspec: Clarify wording, fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To update TOC, please run:
 
 ### Changelog generation has never been so easy
 
-**Fully automated changelog generation** - This gem generates a changelog file based on **tags**, **issues** and merged **pull requests** (and splits them into separate lists according to labels) from :octocat: GitHub Issue Tracker.
+**Fully automated changelog generation** - This gem generates a changelog file based on **tags**, **issues** and merged **pull requests** (and splits them into separate lists according to labels) from :octocat: GitHub.
 
 Since you don't have to fill your `CHANGELOG.md` manually now: just run the script, relax and take a cup of :coffee: before your next release! :tada:
 
@@ -88,7 +88,7 @@ Example invocation:
 
 
 
-- For Github Enterprise repos, specify *both* `--github-site` and `--github-api` options:
+- For GitHub Enterprise repos, specify *both* `--github-site` and `--github-api` options:
 
        $ github_changelog_generator --github-site="https://github.yoursite.com" \
                                   --github-api="https://github.yoursite.com/api/v3/"
@@ -320,7 +320,7 @@ Workaround: Create a `C:\tmp`.
 
 ## Contributing
 
-We have collected notes on how to contribute to this project in [CONTRIBUTING.md].
+Would you like to contribute to this project? [CONTRIBUTING.md] has all the details on how to do that.
 
 [CONTRIBUTING.md]: CONTRIBUTING.md
 
@@ -329,4 +329,4 @@ We have collected notes on how to contribute to this project in [CONTRIBUTING.md
 
 ## License
 
-Github Changelog Generator is released under the [MIT License](http://www.opensource.org/licenses/MIT).
+GitHub Changelog Generator is released under the [MIT License](http://www.opensource.org/licenses/MIT).

--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |spec|
   spec.authors = ["Petr Korolev", "Olle Jonsson", "Marco Ferrari"]
   spec.email = "sky4winder+github_changelog_generator@gmail.com"
 
-  spec.summary = "Script, that automatically generate changelog from your tags, issues, labels and pull requests."
-  spec.description = "Changelog generation has never been so easy. Fully automate changelog generation - this gem generate changelog file based on tags, issues and merged pull requests from Github issue tracker."
+  spec.summary = "Script that automatically generates a changelog from your tags, issues, labels and pull requests."
+  spec.description = "Changelog generation has never been so easy. Fully automate changelog generation - this gem generate changelog file based on tags, issues and merged pull requests from GitHub."
   spec.homepage = "https://github.com/github-changelog-generator/Github-Changelog-Generator"
   spec.license = "MIT"
 


### PR DESCRIPTION
This PR updates the README slightly, and spells GitHub with a H.