### PR TITLE
argv_parser: Ensure that YAML is loaded before use

### DIFF
--- a/lib/github_changelog_generator/argv_parser.rb
+++ b/lib/github_changelog_generator/argv_parser.rb
@@ -73,6 +73,7 @@ module GitHubChangelogGenerator
           options[:add_sections] = v
         end
         opts.on("--front-matter JSON", "Add YAML front matter. Formatted as JSON because it's easier to add on the command line.") do |v|
+          require "yaml"
           options[:frontmatter] = "#{JSON.parse(v).to_yaml}---\n"
         end
         opts.on("--pr-label LABEL", "Set up custom label for pull requests section. Default is \"**Merged pull requests:**\".") do |v|


### PR DESCRIPTION
Fixes #962

How I attempted to fix this: 

- First, run the tool with the option frontmatter, with some JSON
- Observe that the  have it be parser correctly into a Hash, which then didn't have the to_yaml method on it. 

The issue has been there some time.

/Users/olle/.rvm/gems/ruby-2.7.1/gems/github_changelog_generator-1.16.0/lib/github_changelog_generator/parser.rb:92:in `block (2 levels) in setup_parser': undefined method `to_yaml' for {"hello"=>"world"}:Hash (NoMethodError)

This PR makes sure that the YAML code is loaded before trying to use it.