### PR TITLE
Feat: Allow named markdown anchor links

### DIFF
--- a/lib/github_changelog_generator/reader.rb
+++ b/lib/github_changelog_generator/reader.rb
@@ -29,7 +29,7 @@ module GitHubChangelogGenerator
       defaults = {
         heading_level: "##",
         heading_structures: [
-          /^## \[(?<version>.+?)\]\((?<url>.+?)\)( \((?<date>.+?)\))?$/, # rubocop:disable Lint/MixedRegexpCaptureTypes
+          /^## \[(?<version>.+?)\](\((?<url>.+?)\))?( \((?<date>.+?)\))?$/, # rubocop:disable Lint/MixedRegexpCaptureTypes
           /^## (?<version>.+?)( \((?<date>.+?)\))?$/ # rubocop:disable Lint/MixedRegexpCaptureTypes
         ]
       }
@@ -45,6 +45,8 @@ module GitHubChangelogGenerator
     # The following heading structures are currently valid:
     # - ## [v1.0.2](https://github.com/zanui/chef-thumbor/tree/v1.0.1) (2015-03-24)
     # - ## [v1.0.2](https://github.com/zanui/chef-thumbor/tree/v1.0.1)
+    # - ## [v1.0.2] (2015-03-24)
+    # - ## [v1.0.2]
     # - ## v1.0.2 (2015-03-24)
     # - ## v1.0.2
     #

--- a/spec/unit/reader_spec.rb
+++ b/spec/unit/reader_spec.rb
@@ -38,6 +38,15 @@ describe GitHubChangelogGenerator::Reader do
       it { is_expected.to include("url" => "https://github.com/github-changelog-generator/Github-Changelog-Generator/tree/1.3.10") }
       it { is_expected.to include("date" => "2015-03-18") }
     end
+    context "when given a named link" do
+      subject { @reader.parse_heading("## [1.3.10]") }
+      it { is_expected.to include("version" => "1.3.10") }
+    end
+    context "when given a named link with date" do
+      subject { @reader.parse_heading("## [1.3.10] (2015-03-18)") }
+      it { is_expected.to include("version" => "1.3.10") }
+      it { is_expected.to include("date" => "2015-03-18") }
+    end
     context "when no url and date is provided" do
       subject { @reader.parse_heading("## foobar") }
       it { is_expected.to include("version" => "foobar", "url" => nil, "date" => nil) }


### PR DESCRIPTION
Markdown links don't always have their urls attached. Named links allow
putting them afterwards. This change allows the reader to understand
this pattern on the tag headers:

    ## [1.0.0]

    This is version 1.0.0

    ## [0.9.1]

    This is version 0.9.1

    ## [0.9.0]
    ...

    [1.0.0]: https://github.com/myorg/myrepo/compare/0.9.1...1.0.0
    [0.9.1]: https://github.com/myorg/myrepo/compare/0.9.1...0.9.0
    ...

Without this change, the generator will get confused by the brackets
around the versions, and complain that "it cannot find the [1.0.0]
tag" on `all_tags` (which don't have the brackets)