### PR TITLE
Directly handle rate limiting using `client.rate_limit.resets_in`.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
       octokit (~> 4.6)
       rainbow (>= 2.2.1)
       rake (>= 10.0)
-      retriable (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -95,7 +94,6 @@ GEM
     rainbow (3.0.0)
     rake (13.0.1)
     regexp_parser (1.8.1)
-    retriable (3.1.2)
     rexml (3.2.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)

--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -31,5 +31,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("octokit", ["~> 4.6"])
   spec.add_runtime_dependency "rainbow", ">= 2.2.1"
   spec.add_runtime_dependency "rake", ">= 10.0"
-  spec.add_runtime_dependency("retriable", ["~> 3.0"])
 end

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -463,7 +463,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
       resets_in = client.rate_limit.resets_in
       Helper.log.error("#{e.class} #{e.message}; sleeping for #{resets_in}s...")
 
-      if task = Async::Task.current?
+      if (task = Async::Task.current?)
         task.sleep(resets_in)
       else
         sleep(resets_in)

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "tmpdir"
-require "retriable"
 require "set"
 require "async"
 require "async/barrier"
@@ -456,10 +455,21 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
     #
     # @return [Object] returns exactly the same, what you put in the block, but wrap it with begin-rescue block
     # @param [Proc] block
-    def check_github_response(&block)
-      Retriable.retriable(retry_options, &block)
+    def check_github_response
+      yield
     rescue MovedPermanentlyError => e
       fail_with_message(e, "The repository has moved, update your configuration")
+    rescue Octokit::TooManyRequests => e
+      resets_in = client.rate_limit.resets_in
+      Helper.log.error("#{e.class} #{e.message}; sleeping for #{resets_in}s...")
+
+      if task = Async::Task.current?
+        task.sleep(resets_in)
+      else
+        sleep(resets_in)
+      end
+
+      retry
     rescue Octokit::Forbidden => e
       fail_with_message(e, "Exceeded retry limit")
     rescue Octokit::Unauthorized => e
@@ -472,31 +482,6 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
     def fail_with_message(error, message)
       Helper.log.error("#{error.class}: #{error.message}")
       sys_abort(message)
-    end
-
-    # Exponential backoff
-    def retry_options
-      {
-        on: [Octokit::Forbidden],
-        tries: MAX_FORBIDDEN_RETRIES,
-        base_interval: sleep_base_interval,
-        multiplier: 1.0,
-        rand_factor: 0.0,
-        on_retry: retry_callback
-      }
-    end
-
-    def sleep_base_interval
-      1.0
-    end
-
-    def retry_callback
-      proc do |exception, try, elapsed_time, next_interval|
-        Helper.log.warn("RETRY - #{exception.class}: '#{exception.message}'")
-        Helper.log.warn("#{try} tries in #{elapsed_time} seconds and #{next_interval} seconds until the next try")
-        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG
-        Helper.log.warn(client.rate_limit)
-      end
     end
 
     # @param [Object] msg

--- a/spec/unit/octo_fetcher_spec.rb
+++ b/spec/unit/octo_fetcher_spec.rb
@@ -29,8 +29,6 @@ describe GitHubChangelogGenerator::OctoFetcher do
 
     context "when raises Octokit::Forbidden" do
       it "sleeps and retries and then aborts" do
-        retry_limit = GitHubChangelogGenerator::OctoFetcher::MAX_FORBIDDEN_RETRIES - 1
-
         expect(fetcher).to receive(:sys_abort).with("Exceeded retry limit")
         fetcher.send(:check_github_response) { raise(Octokit::Forbidden) }
       end

--- a/spec/unit/octo_fetcher_spec.rb
+++ b/spec/unit/octo_fetcher_spec.rb
@@ -30,7 +30,6 @@ describe GitHubChangelogGenerator::OctoFetcher do
     context "when raises Octokit::Forbidden" do
       it "sleeps and retries and then aborts" do
         retry_limit = GitHubChangelogGenerator::OctoFetcher::MAX_FORBIDDEN_RETRIES - 1
-        allow(fetcher).to receive(:sleep_base_interval).exactly(retry_limit).times.and_return(0)
 
         expect(fetcher).to receive(:sys_abort).with("Exceeded retry limit")
         fetcher.send(:check_github_response) { raise(Octokit::Forbidden) }


### PR DESCRIPTION
We discussed some issues here, and at least when I tried, it, I ran into rate limiting issues.

https://github.com/github-changelog-generator/github-changelog-generator/discussions/965#discussioncomment-816764

This PR tries to respect GitHub's rate limiting.