### PR TITLE
Extract GitHubChangelogGenerator::FileParserChooser to its own file

### DIFF
--- a/lib/github_changelog_generator/file_parser_chooser.rb
+++ b/lib/github_changelog_generator/file_parser_chooser.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+module GitHubChangelogGenerator
+  class FileParserChooser
+    def initialize(options)
+      @options     = options
+      @config_file = Pathname.new(options[:config_file])
+    end
+
+    def parse!(_argv)
+      return nil unless (path = resolve_path)
+
+      ParserFile.new(@options, File.open(path)).parse!
+    end
+
+    def resolve_path
+      return @config_file if @config_file.exist?
+
+      path = @config_file.expand_path
+      return path if File.exist?(path)
+
+      nil
+    end
+  end
+end

--- a/lib/github_changelog_generator/file_parser_chooser.rb
+++ b/lib/github_changelog_generator/file_parser_chooser.rb
@@ -5,7 +5,7 @@ require "pathname"
 module GitHubChangelogGenerator
   class FileParserChooser
     def initialize(options)
-      @options     = options
+      @options = options
       @config_file = Pathname.new(options[:config_file])
     end
 

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -4,6 +4,7 @@
 require "github_changelog_generator/helper"
 require "github_changelog_generator/argv_parser"
 require "github_changelog_generator/parser_file"
+require "github_changelog_generator/file_parser_chooser"
 
 module GitHubChangelogGenerator
   class Parser

--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -1,31 +1,7 @@
 # frozen_string_literal: true
 
-require "pathname"
-
 module GitHubChangelogGenerator
   ParserError = Class.new(StandardError)
-
-  class FileParserChooser
-    def initialize(options)
-      @options     = options
-      @config_file = Pathname.new(options[:config_file])
-    end
-
-    def parse!(_argv)
-      return nil unless (path = resolve_path)
-
-      ParserFile.new(@options, File.open(path)).parse!
-    end
-
-    def resolve_path
-      return @config_file if @config_file.exist?
-
-      path = @config_file.expand_path
-      return path if File.exist?(path)
-
-      nil
-    end
-  end
 
   # ParserFile is a configuration file reader which sets options in the
   # given Hash.


### PR DESCRIPTION
Minor change that moves the FileParserChooser class into it's own file.