### PR TITLE
refactor: Unnest conditionals in tag-related methods, deprecate an ill-named method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,10 +52,6 @@ Naming/FileName:
 Metrics/AbcSize:
   Enabled: false
 
-# Offense count: 1
-Naming/AccessorMethodName:
-  Enabled: false
-
 # Offense count: 10
 Style/Documentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,15 +50,10 @@ Naming/FileName:
 # TODOS
 # Offense count: 14
 Metrics/AbcSize:
-  Enabled: false
+  Enabled: false  
 
 # Offense count: 10
 Style/Documentation:
-  Enabled: false
-
-# Offense count: 1
-# Configuration parameters: MinBodyLength.
-Style/GuardClause:
   Enabled: false
 
 # Offense count: 2

--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -160,7 +160,7 @@ module GitHubChangelogGenerator
       compare_string = issue["merged_at"].nil? ? "closed" : "merged"
       # reverse! - to find latest closed event. (event goes in date order)
       issue["events"].reverse!.each do |event|
-        if event["event"].eql? compare_string
+        if event["event"] == compare_string
           set_date_from_event(event, issue)
           break
         end

--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -154,15 +154,15 @@ module GitHubChangelogGenerator
     # Fill :actual_date parameter of specified issue by closed date of the commit, if it was closed by commit.
     # @param [Hash] issue
     def find_closed_date_by_commit(issue)
-      unless issue["events"].nil?
-        # if it's PR -> then find "merged event", in case of usual issue -> fond closed date
-        compare_string = issue["merged_at"].nil? ? "closed" : "merged"
-        # reverse! - to find latest closed event. (event goes in date order)
-        issue["events"].reverse!.each do |event|
-          if event["event"].eql? compare_string
-            set_date_from_event(event, issue)
-            break
-          end
+      return if issue["events"].nil?
+
+      # if it's PR -> then find "merged event", in case of usual issue -> fond closed date
+      compare_string = issue["merged_at"].nil? ? "closed" : "merged"
+      # reverse! - to find latest closed event. (event goes in date order)
+      issue["events"].reverse!.each do |event|
+        if event["event"].eql? compare_string
+          set_date_from_event(event, issue)
+          break
         end
       end
       # TODO: assert issues, that remain without 'actual_date' hash for some reason.
@@ -175,17 +175,16 @@ module GitHubChangelogGenerator
     def set_date_from_event(event, issue)
       if event["commit_id"].nil?
         issue["actual_date"] = issue["closed_at"]
-      else
-        begin
-          commit = @fetcher.fetch_commit(event["commit_id"])
-          issue["actual_date"] = commit["commit"]["author"]["date"]
-
-          # issue['actual_date'] = commit['author']['date']
-        rescue StandardError
-          puts "Warning: Can't fetch commit #{event['commit_id']}. It is probably referenced from another repo."
-          issue["actual_date"] = issue["closed_at"]
-        end
+        return
       end
+
+      commit = @fetcher.fetch_commit(event["commit_id"])
+      issue["actual_date"] = commit["commit"]["author"]["date"]
+
+      # issue['actual_date'] = commit['author']['date']
+    rescue StandardError
+      puts "Warning: Can't fetch commit #{event['commit_id']}. It is probably referenced from another repo."
+      issue["actual_date"] = issue["closed_at"]
     end
 
     private

--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -156,7 +156,7 @@ module GitHubChangelogGenerator
     def find_closed_date_by_commit(issue)
       return if issue["events"].nil?
 
-      # if it's PR -> then find "merged event", in case of usual issue -> fond closed date
+      # if it's PR -> then find "merged event", in case of usual issue -> found closed date
       compare_string = issue["merged_at"].nil? ? "closed" : "merged"
       # reverse! - to find latest closed event. (event goes in date order)
       issue["events"].reverse!.each do |event|

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -195,7 +195,7 @@ module GitHubChangelogGenerator
     end
 
     def warn_if_nonmatching_regex(all_tags, regex, regex_option_name)
-      return if all_tags.any? { |t| regex =~ t["name"] }
+      return if all_tags.any? { |t| regex.match?(t["name"]) }
 
       Helper.log.warn "Warning: unable to reject any tag, using regex "\
                       "#{regex.inspect} in #{regex_option_name} option."

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -119,41 +119,29 @@ module GitHubChangelogGenerator
     # @param [Array] all_tags all tags
     # @return [Array] filtered tags according :since_tag option
     def filter_since_tag(all_tags)
-      filtered_tags = all_tags
-      tag = since_tag
-      if tag
-        if all_tags.map { |t| t["name"] }.include? tag
-          idx = all_tags.index { |t| t["name"] == tag }
-          filtered_tags = if idx
-                            all_tags[0..idx]
-                          else
-                            []
-                          end
-        else
-          raise ChangelogGeneratorError, "Error: can't find tag #{tag}, specified with --since-tag option."
-        end
+      return all_tags unless (tag = since_tag)
+
+      raise ChangelogGeneratorError, "Error: can't find tag #{tag}, specified with --since-tag option." if all_tags.none? { |t| t["name"] == tag }
+
+      if (idx = all_tags.index { |t| t["name"] == tag })
+        all_tags[0..idx]
+      else
+        []
       end
-      filtered_tags
     end
 
     # @param [Array] all_tags all tags
     # @return [Array] filtered tags according :due_tag option
     def filter_due_tag(all_tags)
-      filtered_tags = all_tags
-      tag           = due_tag
-      if tag
-        if all_tags.any? && all_tags.map { |t| t["name"] }.include?(tag)
-          idx = all_tags.index { |t| t["name"] == tag }
-          filtered_tags = if idx > 0
-                            all_tags[(idx + 1)..-1]
-                          else
-                            []
-                          end
-        else
-          raise ChangelogGeneratorError, "Error: can't find tag #{tag}, specified with --due-tag option."
-        end
+      return all_tags unless (tag = due_tag)
+
+      raise ChangelogGeneratorError, "Error: can't find tag #{tag}, specified with --due-tag option." if all_tags.none? { |t| t["name"] == tag }
+
+      if (idx = all_tags.index { |t| t["name"] == tag }) > 0
+        all_tags[(idx + 1)..-1]
+      else
+        []
       end
-      filtered_tags
     end
 
     # @param [Array] all_tags all tags
@@ -207,14 +195,16 @@ module GitHubChangelogGenerator
     end
 
     def warn_if_nonmatching_regex(all_tags, regex, regex_option_name)
-      unless all_tags.map { |t| t["name"] }.any? { |t| regex =~ t }
-        Helper.log.warn "Warning: unable to reject any tag, using regex "\
-                        "#{regex.inspect} in #{regex_option_name} option."
-      end
+      return if all_tags.any? { |t| regex =~ t["name"] }
+
+      Helper.log.warn "Warning: unable to reject any tag, using regex "\
+                      "#{regex.inspect} in #{regex_option_name} option."
     end
 
     def warn_if_tag_not_found(all_tags, tag)
-      Helper.log.warn("Warning: can't find tag #{tag}, specified with --exclude-tags option.") unless all_tags.map { |t| t["name"] }.include?(tag)
+      return if all_tags.any? { |t| t["name"] == tag }
+
+      Helper.log.warn("Warning: can't find tag #{tag}, specified with --exclude-tags option.")
     end
   end
 end

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -7,7 +7,7 @@ module GitHubChangelogGenerator
       since_tag
       due_tag
 
-      all_tags = @fetcher.get_all_tags
+      all_tags = @fetcher.fetch_all_tags
       fetch_tags_dates(all_tags) # Creates a Hash @tag_times_hash
       all_sorted_tags = sort_tags_by_date(all_tags)
 

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -101,6 +101,11 @@ module GitHubChangelogGenerator
       check_github_response { github_fetch_tags }
     end
 
+    def get_all_tags # rubocop:disable Naming/AccessorMethodName
+      warn("[DEPRECATED] GitHubChangelogGenerator::OctoFetcher#get_all_tags is deprecated; use fetch_all_tags instead.")
+      fetch_all_tags
+    end
+
     # Returns the number of pages for a API call
     #
     # @return [Integer] number of pages for this API call in total

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -95,7 +95,7 @@ module GitHubChangelogGenerator
     # Fetch all tags from repo
     #
     # @return [Array <Hash>] array of tags
-    def get_all_tags
+    def fetch_all_tags
       print "Fetching tags...\r" if @options[:verbose]
 
       check_github_response { github_fetch_tags }

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -49,7 +49,7 @@ describe GitHubChangelogGenerator::Generator do
     let(:generator) { described_class.new(default_options.merge(options)) }
 
     before do
-      allow_any_instance_of(GitHubChangelogGenerator::OctoFetcher).to receive(:get_all_tags).and_return(all_tags)
+      allow_any_instance_of(GitHubChangelogGenerator::OctoFetcher).to receive(:fetch_all_tags).and_return(all_tags)
       allow(generator).to receive(:fetch_tags_dates).with(all_tags)
       allow(generator).to receive(:sort_tags_by_date).with(all_tags).and_return(sorted_tags)
       generator.fetch_and_filter_tags

--- a/spec/unit/octo_fetcher_spec.rb
+++ b/spec/unit/octo_fetcher_spec.rb
@@ -72,12 +72,12 @@ describe GitHubChangelogGenerator::OctoFetcher do
     end
   end
 
-  describe "#get_all_tags" do
+  describe "#fetch_all_tags" do
     context "when github_fetch_tags returns tags" do
       it "returns tags" do
         mock_tags = ["tag"]
         allow(fetcher).to receive(:github_fetch_tags).and_return(mock_tags)
-        expect(fetcher.get_all_tags).to eq(mock_tags)
+        expect(fetcher.fetch_all_tags).to eq(mock_tags)
       end
     end
   end


### PR DESCRIPTION
Took a little time to refactor a few tag related methods, inspired by removing the Cop `Style/GuardClause` from the RuboCop ignore list.