### PR TITLE
Add coverage to parser file spec

### DIFF
--- a/spec/unit/parser_file_spec.rb
+++ b/spec/unit/parser_file_spec.rb
@@ -3,15 +3,18 @@
 describe GitHubChangelogGenerator::ParserFile do
   describe ".github_changelog_generator" do
     let(:options) { {} }
+    let(:parser) { GitHubChangelogGenerator::ParserFile.new(options, file) }
 
     context "when the well-known default file does not exist" do
-      let(:parser) { GitHubChangelogGenerator::ParserFile.new(options) }
+      let(:file) { nil }
+
       subject { parser.parse! }
+
       it { is_expected.to be_nil }
     end
 
     context "when file is empty" do
-      let(:parser) { GitHubChangelogGenerator::ParserFile.new(options, StringIO.new("")) }
+      let(:file) { StringIO.new("") }
 
       it "does not change the options" do
         expect { parser.parse! }.to_not(change { options })
@@ -19,19 +22,14 @@ describe GitHubChangelogGenerator::ParserFile do
     end
 
     context "when file is incorrect" do
-      let(:options_before_change) { options.dup }
       let(:file) { StringIO.new("unreleased_label=staging\nunreleased: false") }
-      let(:parser) do
-        GitHubChangelogGenerator::ParserFile.new(options, file)
-      end
+
       it { expect { parser.parse! }.to raise_error(/line #2/) }
     end
 
     context "allows empty lines and comments with semi-colon or pound sign" do
       let(:file) { StringIO.new("\n   \n# Comment on first line\nunreleased_label=staging\n; Comment on third line\nunreleased=false") }
-      let(:parser) do
-        GitHubChangelogGenerator::ParserFile.new(options, file)
-      end
+
       it { expect { parser.parse! }.not_to raise_error }
     end
 
@@ -40,7 +38,6 @@ describe GitHubChangelogGenerator::ParserFile do
       let(:options) { {}.merge(default_options) }
       let(:options_before_change) { options.dup }
       let(:file) { StringIO.new("unreleased_label=staging\nunreleased=false\nheader==== Changelog ===") }
-      let(:parser) { GitHubChangelogGenerator::ParserFile.new(options, file) }
 
       it "changes the options" do
         expect { parser.parse! }.to change { options }

--- a/spec/unit/parser_file_spec.rb
+++ b/spec/unit/parser_file_spec.rb
@@ -3,10 +3,10 @@
 describe GitHubChangelogGenerator::ParserFile do
   describe ".github_changelog_generator" do
     let(:options) { {} }
-    let(:parser) { GitHubChangelogGenerator::ParserFile.new(options, StringIO.new(file)) }
+    let(:parser) { described_class.new(options, StringIO.new(file)) }
 
     context "when the well-known default file does not exist" do
-      let(:parser) { GitHubChangelogGenerator::ParserFile.new(options) }
+      let(:parser) { described_class.new(options) }
 
       subject { parser.parse! }
 

--- a/spec/unit/parser_file_spec.rb
+++ b/spec/unit/parser_file_spec.rb
@@ -22,23 +22,25 @@ describe GitHubChangelogGenerator::ParserFile do
     end
 
     context "when file is incorrect" do
-      let(:file) { <<~FILE.strip
-        unreleased_label=staging
-        unreleased: false
-      FILE
-      }
+      let(:file) do
+        <<~FILE.strip
+          unreleased_label=staging
+          unreleased: false
+        FILE
+      end
 
       it { expect { parser.parse! }.to raise_error(/line #2/) }
     end
 
     context "allows empty lines and comments with semi-colon or pound sign" do
-      let(:file) { "\n   \n" + <<~REMANING.strip
-        # Comment on first line
-        unreleased_label=staging
-        ; Comment on third line
-        unreleased=false
-      REMANING
-      }
+      let(:file) do
+        "\n   \n#{<<~REMANING.strip}"
+          # Comment on first line
+          unreleased_label=staging
+          ; Comment on third line
+          unreleased=false
+        REMANING
+      end
 
       it { expect { parser.parse! }.not_to raise_error }
     end
@@ -47,14 +49,15 @@ describe GitHubChangelogGenerator::ParserFile do
       let(:default_options) { GitHubChangelogGenerator::Parser.default_options.merge(verbose: false) }
       let(:options) { {}.merge(default_options) }
       let(:options_before_change) { options.dup }
-      let(:file) { <<~FILE.strip
+      let(:file) do
+        <<~FILE.strip
           unreleased_label=staging
           unreleased=false
           header==== Changelog ===
           max_issues=123
           simple-list=true
         FILE
-      }
+      end
 
       it "changes the options" do
         expect { parser.parse! }.to change { options }
@@ -67,11 +70,12 @@ describe GitHubChangelogGenerator::ParserFile do
       end
 
       context "turns exclude-labels into an Array", bug: "#327" do
-        let(:file) { <<~FILE
+        let(:file) do
+          <<~FILE
             exclude-labels=73a91042-da6f-11e5-9335-1040f38d7f90,7adf83b4-da6f-11e5-ae18-1040f38d7f90
             header_label=# My changelog
           FILE
-        }
+        end
 
         it "reads exclude_labels into an Array" do
           expect { parser.parse! }.to change { options[:exclude_labels] }

--- a/spec/unit/parser_file_spec.rb
+++ b/spec/unit/parser_file_spec.rb
@@ -34,12 +34,12 @@ describe GitHubChangelogGenerator::ParserFile do
 
     context "allows empty lines and comments with semi-colon or pound sign" do
       let(:file) do
-        "\n   \n#{<<~REMANING.strip}"
+        "\n   \n#{<<~REMAINING.strip}"
           # Comment on first line
           unreleased_label=staging
           ; Comment on third line
           unreleased=false
-        REMANING
+        REMAINING
       end
 
       it { expect { parser.parse! }.not_to raise_error }


### PR DESCRIPTION
This PR:

- fixes the spec file name
- refactors the test structure for the `GitHubChangelogGenerator::ParserFile`
- enhances the coverage by covering the parsing of integer and truthy boolean values