### PR TITLE
Extract find_tag_for_milestone method

### DIFF
--- a/spec/unit/generator/generator_processor_spec.rb
+++ b/spec/unit/generator/generator_processor_spec.rb
@@ -138,6 +138,36 @@ module GitHubChangelogGenerator
         end
       end
 
+      describe "#find_issues_to_add" do
+        let(:issues) { [issue] }
+        let(:tag_name) { nil }
+        let(:filtered_tags) { [] }
+        before { generator.instance_variable_set(:@filtered_tags, filtered_tags) }
+
+        subject { generator.find_issues_to_add(issues, tag_name) }
+
+        context "issue without milestone" do
+          let(:issue) { { "labels" => [] } }
+
+          it { is_expected.to be_empty }
+        end
+
+        context "milestone title not in the filtered tags" do
+          let(:issue) { { "milestone" => { "title" => "a title" } } }
+          let(:filtered_tags) { [{ "name" => "another name" }] }
+
+          it { is_expected.to be_empty }
+        end
+
+        context "milestone title matches the tag name" do
+          let(:tag_name) { "tag name" }
+          let(:issue) { { "milestone" => { "title" => tag_name } } }
+          let(:filtered_tags) { [{ "name" => tag_name }] }
+
+          it { is_expected.to contain_exactly(issue) }
+        end
+      end
+
       describe "#remove_issues_in_milestones" do
         let(:issues) { [issue] }
 

--- a/spec/unit/generator/generator_processor_spec.rb
+++ b/spec/unit/generator/generator_processor_spec.rb
@@ -193,7 +193,7 @@ module GitHubChangelogGenerator
           let(:issue) { { "milestone" => { "title" => milestone_name } } }
 
           it "is filtered" do
-            generator.instance_variable_set(:@filtered_tags, [ { "name" => milestone_name } ])
+            generator.instance_variable_set(:@filtered_tags, [{ "name" => milestone_name }])
             expect { generator.remove_issues_in_milestones(issues) }.to change { issues }.to([])
           end
         end


### PR DESCRIPTION
This PR:

- adds code coverage for `GitHubChangelogGenerator::Generator.find_issues_to_add`
- extract a method `GitHubChangelogGenerator::Generator.find_tag_for_milestone` for removing duplication between `find_issues_to_add` and `remove_issues_in_milestones`