### PR TITLE
docs: Fix filename in option to gh release command

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Then use the [release create](https://cli.github.com/manual/gh_release_create) f
 
 ```
 gh release create 2.0.0 \
-  --notes-file build/changelog \
+  --notes-file build/changelog.md \
   --title 2.0.0
 ```
 


### PR DESCRIPTION
The suffix we had used when generating the Markdown file seemed to be missing. This repairs a typo.