### PR TITLE
Improve spec coverage for pull request association

### DIFF
--- a/lib/github_changelog_generator/generator/generator.rb
+++ b/lib/github_changelog_generator/generator/generator.rb
@@ -149,7 +149,12 @@ module GitHubChangelogGenerator
 
       fetch_events_for_issues_and_pr
       detect_actual_closed_dates(@issues + @pull_requests)
-      add_first_occurring_tag_to_prs(@sorted_tags, @pull_requests)
+      prs_left = add_first_occurring_tag_to_prs(@sorted_tags, @pull_requests)
+
+      # PRs in prs_left will be untagged, not in release branch, and not
+      # rebased. They should not be included in the changelog as they probably
+      # have been merged to a branch other than the release branch.
+      @pull_requests -= prs_left
       nil
     end
 

--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -48,11 +48,10 @@ module GitHubChangelogGenerator
       prs_left = associate_tagged_prs(tags, prs, total)
       prs_left = associate_release_branch_prs(prs_left, total)
       prs_left = associate_rebase_comment_prs(tags, prs_left, total) if prs_left.any?
-      # PRs in prs_left will be untagged, not in release branch, and not
-      # rebased. They should not be included in the changelog as they probably
-      # have been merged to a branch other than the release branch.
-      @pull_requests -= prs_left
+
       Helper.log.info "Associating PRs with tags: #{total}/#{total}"
+
+      prs_left
     end
 
     # Associate merged PRs by the merge SHA contained in each tag. If the

--- a/spec/unit/generator/generator_spec.rb
+++ b/spec/unit/generator/generator_spec.rb
@@ -152,5 +152,13 @@ RSpec.describe GitHubChangelogGenerator::Generator do
       expect { generator.send(:add_first_occurring_tag_to_prs, tags, prs) }
         .to raise_error StandardError, "PR 23 has a rebased SHA comment but that SHA was not found in the release branch or any tags"
     end
+
+    it "raises an error for prs without merge commit or rebase comment" do
+      prs = [{ "number" => "23" }]
+      tags = [{ "name" => "v1.0", "shas_in_tag" => [sha(1), sha(2)] }]
+
+      expect { generator.send(:add_first_occurring_tag_to_prs, tags, prs) }
+        .to raise_error StandardError, "No merge sha found for PR 23 via the GitHub API"
+    end
   end
 end

--- a/spec/unit/generator/generator_spec.rb
+++ b/spec/unit/generator/generator_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe GitHubChangelogGenerator::Generator do
       end
     end
 
-    it "detects prs merged via rebase in a tag" do
+    it "detects closed prs marked as rebased in a tag" do
       prs = [{ "comments" => [{ "body" => "rebased commit: #{sha(2)}" }] }]
       tags = [{ "name" => "v1.0", "shas_in_tag" => [sha(1), sha(2)] }]
 
@@ -115,7 +115,7 @@ RSpec.describe GitHubChangelogGenerator::Generator do
       end
     end
 
-    it "detects prs merged via rebase in the release branch" do
+    it "detects closed prs marked as rebased in the release branch" do
       prs = [{ "comments" => [{ "body" => "rebased commit: #{sha(4)}" }] }]
       tags = [{ "name" => "v1.0", "shas_in_tag" => [sha(1), sha(2)] }]
 
@@ -145,7 +145,7 @@ RSpec.describe GitHubChangelogGenerator::Generator do
       end
     end
 
-    it "raises an error for prs merged via rebase into another branch" do
+    it "raises an error for closed prs marked as rebased to an unknown commit" do
       prs = [{ "number" => "23", "comments" => [{ "body" => "rebased commit: #{sha(5)}" }] }]
       tags = [{ "name" => "v1.0", "shas_in_tag" => [sha(1), sha(2)] }]
 
@@ -153,7 +153,7 @@ RSpec.describe GitHubChangelogGenerator::Generator do
         .to raise_error StandardError, "PR 23 has a rebased SHA comment but that SHA was not found in the release branch or any tags"
     end
 
-    it "raises an error for prs without merge commit or rebase comment" do
+    it "raises an error for prs without merge event or rebase comment" do
       prs = [{ "number" => "23" }]
       tags = [{ "name" => "v1.0", "shas_in_tag" => [sha(1), sha(2)] }]
 


### PR DESCRIPTION
This is a preparatory pull request for doing refactoring of the code that associates pull requests with tags and branches. This code was not well covered by specs so this pull request fixes that.

- Adjust pull requests list where it is created
- Add specs for assignment of PRs to tags and release branch
- Add assertions about calls to fetcher when assigning PRs
- Add spec for exception when PR has neither merge event nor rebase comment
- Improve spec descriptions
- Cover the case where a pull request was merged and then rebased
