### PR TITLE
Add option "tag-order"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Ruby CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, feature/semantic-version-sort ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Ruby CI
 
 on:
   push:
-    branches: [ master, feature/semantic-version-sort ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/lib/github_changelog_generator/argv_parser.rb
+++ b/lib/github_changelog_generator/argv_parser.rb
@@ -205,6 +205,9 @@ module GitHubChangelogGenerator
         opts.on("--[no-]verbose", "Run verbosely. Default is true.") do |v|
           options[:verbose] = v
         end
+        opts.on("--tag-order ORDER", "Tag ordering method. Two methods available: 'date' and 'semver'. Default is 'date'.") do |tag_order|
+          options[:tag_order] = tag_order
+        end
         opts.on("-v", "--version", "Print version number.") do |_v|
           puts "Version: #{GitHubChangelogGenerator::VERSION}"
           exit

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -47,9 +47,22 @@ module GitHubChangelogGenerator
 
     # Sort all tags by date, newest to oldest
     def sort_tags_by_date(tags)
-      puts "Sorting tags..." if options[:verbose]
+      puts "Sorting tags by date..." if options[:verbose]
       tags.sort_by! do |x|
         get_time_of_tag(x)
+      end.reverse!
+    end
+
+    
+    # Sort all tags by semantic version
+    def sort_tags_by_semantic_version(tags)
+      puts "Sorting tags by semantic version..." if options[:verbose]
+      tags.sort_by! do |x|
+        parts = version.split('-')
+        main_parts = parts[0].split('.')
+        pre_release_parts = parts[1] ? parts[1].split('.') : []
+        build_metadata_parts = parts[2] ? parts[2].split('.') : []
+        [main_parts.map(&:to_id), pre_release_parts, build_metadata_parts]
       end.reverse!
     end
 

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -53,15 +53,14 @@ module GitHubChangelogGenerator
       end.reverse!
     end
 
-    
     # Sort all tags by semantic version
     def sort_tags_by_semantic_version(tags)
       puts "Sorting tags by semantic version..." if options[:verbose]
       tags.sort_by! do |x|
-        parts = version.split('-')
-        main_parts = parts[0].split('.')
-        pre_release_parts = parts[1] ? parts[1].split('.') : []
-        build_metadata_parts = parts[2] ? parts[2].split('.') : []
+        parts = x.split("-")
+        main_parts = parts[0].split(".")
+        pre_release_parts = parts[1] ? parts[1].split(".") : []
+        build_metadata_parts = parts[2] ? parts[2].split(".") : []
         [main_parts.map(&:to_id), pre_release_parts, build_metadata_parts]
       end.reverse!
     end

--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -69,6 +69,7 @@ module GitHubChangelogGenerator
       ssl_ca_file
       summary_labels
       summary_prefix
+      tag_order
       token
       unreleased
       unreleased_label

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -81,7 +81,8 @@ module GitHubChangelogGenerator
           security_prefix: "**Security fixes:**",
           http_cache: true,
           require: [],
-          config_file: ".github_changelog_generator"
+          config_file: ".github_changelog_generator",
+          tag_order: "date"
         )
       end
     end

--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -19,7 +19,7 @@ module GitHubChangelogGenerator
                   between_tags exclude_tags exclude_tags_regex since_tag max_issues
                   github_site github_endpoint simple_list
                   future_release release_branch verbose release_url
-                  base configure_sections add_sections http_cache]
+                  base configure_sections add_sections http_cache tag_order]
 
     OPTIONS.each do |o|
       attr_accessor o.to_sym

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -321,14 +321,45 @@ describe GitHubChangelogGenerator::Generator do
     subject do
       @generator.sort_tags_by_date(tags)
     end
-    context "sort unsorted tags" do
+    context "sort unsorted date tags" do
       let(:tags) { tags_from_strings %w[valid_tag1 valid_tag2 valid_tag3] }
 
       it { is_expected.to be_a_kind_of(Array) }
       it { is_expected.to match_array(tags.reverse!) }
     end
-    context "sort sorted tags" do
+    context "sort sorted date tags" do
       let(:tags) { tags_from_strings %w[valid_tag3 valid_tag2 valid_tag1] }
+
+      it { is_expected.to be_a_kind_of(Array) }
+      it { is_expected.to match_array(tags) }
+    end
+  end
+
+  describe "#sort_tags_by_semantic_version" do
+    let(:time1) { Time.now }
+
+    before(:all) do
+      @generator = GitHubChangelogGenerator::Generator.new
+    end
+
+    subject do
+      @generator.sort_tags_by_semantic_version(tags)
+    end
+    context "sort unsorted semver tags" do
+      let(:tags) { tags_from_strings ["2.0.0", "1.2.4", "1.2.3+build.1", "1.2.3-beta.1", "2.1.0"] }
+      let(:sorted_tags) { tags_from_strings ["2.1.0", "2.0.0", "1.2.4", "1.2.3+build.1", "1.2.3-beta.1"] }
+      it { is_expected.to be_a_kind_of(Array) }
+      it { is_expected.to match_array(sorted_tags) }
+    end
+    context "sort sorted semver tags" do
+      let(:tags) { tags_from_strings ["2.1.0", "2.0.0", "1.2.4", "1.2.3+build.1", "1.2.3-beta.1"] }
+
+      it { is_expected.to be_a_kind_of(Array) }
+      it { is_expected.to match_array(tags) }
+    end
+
+    context "sort non-semver tags" do
+      let(:tags) { tags_from_strings %w[some_tag1 some_tag2] }
 
       it { is_expected.to be_a_kind_of(Array) }
       it { is_expected.to match_array(tags) }


### PR DESCRIPTION
This PR adds a new flag "tag-order" with two possible values:
- date
- semver

Depending on tag order different strategy is used when tags are sorted.

Unfortunatelly, I'm not Ruby developer but I was trying to improvise. Comments and suggestions are welcomed.

Closes #1017 