### PR TITLE
Fix missing release branch when looking for commits

### DIFF
--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -345,7 +345,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
     # @param [String] name
     # @return [Array<String>]
     def commits_in_branch(name)
-      @branches ||= client.branches(user_project).map { |branch| [branch[:name], branch] }.to_h
+      @branches ||= client.branches(user_project, DEFAULT_REQUEST_OPTIONS).map { |branch| [branch[:name], branch] }.to_h
 
       if (branch = @branches[name])
         commits_in_tag(branch[:commit][:sha])

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -345,7 +345,13 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
     # @param [String] name
     # @return [Array<String>]
     def commits_in_branch(name)
-      @branches ||= client.branches(user_project, DEFAULT_REQUEST_OPTIONS).map { |branch| [branch[:name], branch] }.to_h
+      @branches ||= lambda do
+        iterate_pages(client, "branches") do |branches|
+          branches_map = branches.map { |branch| [branch[:name], branch] }.to_h
+          return branches_map if branches_map[name]
+        end
+        return {}
+      end[]
 
       if (branch = @branches[name])
         commits_in_tag(branch[:commit][:sha])

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -347,11 +347,11 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
     def commits_in_branch(name)
       @branches ||= lambda do
         iterate_pages(client, "branches") do |branches|
-          branches_map = branches.map { |branch| [branch[:name], branch] }.to_h
+          branches_map = branches.to_h { |branch| [branch[:name], branch] }
           return branches_map if branches_map[name]
         end
         return {}
-      end[]
+      end.call
 
       if (branch = @branches[name])
         commits_in_tag(branch[:commit][:sha])


### PR DESCRIPTION
The default responses per page of 30 can cause the release branch to be missed out of the query results during the check for commits in the release branch.

This causes WARNING: `merge commit was not found in the release branch or tagged git history and no rebased SHA comment was found`. https://github.com/github-changelog-generator/github-changelog-generator/issues/971

This PR sets the default query response size to 100 to reduce the likelihood of this happening. A more permanent solution could be to restrict the branches query to the required branch.